### PR TITLE
feature/observation-api fixes

### DIFF
--- a/build-rnnodeapp.sh
+++ b/build-rnnodeapp.sh
@@ -14,6 +14,7 @@ cd ./rnnodeapp && npm i && cd ..;
 
 echo "Minifying...";
 $(npm bin)/noderify \
+  --filter original-fs \
   --replace.leveldown=leveldown-android-prebuilt \
   ./rnnodeapp/index.js > ./rnnodeapp/_index.js;
 rm ./rnnodeapp/index.js;

--- a/src/api/base.js
+++ b/src/api/base.js
@@ -19,7 +19,7 @@ const request = (method: string, route: string, body?: any) => {
       body: encodedBody,
       headers
     })
-  ).flatMap(response => {
+  ).retry(3).flatMap(response => {
     if (response.ok) {
       return Observable.of(response);
     }


### PR DESCRIPTION
## commit: fix rnnodeapp build script

By ignoring an Electron-specific package, "original-fs", leftover from mapeo-mobile-server.

## commit: retry localhost requests

While rnnodeapp is still starting up, the frontend may be too eager and send a request to it. This is a race condition, and the frontend's request will fail. This commit adds a quick and weak fix to it, by retrying failed requests at least 3 times. Often this is enough to create some waiting time until rnnodeapp is up.