### PR TITLE
Flatten app state

### DIFF
--- a/src/components/Base/FieldInput/index.js
+++ b/src/components/Base/FieldInput/index.js
@@ -8,7 +8,7 @@ import type { StateProps } from './FieldInput';
 
 function mapStateToProps(state: StoreState): StateProps {
   return {
-    selectedObservation: state.app.selectedObservation
+    selectedObservation: state.selectedObservation
   };
 }
 

--- a/src/components/Base/Header/index.js
+++ b/src/components/Base/Header/index.js
@@ -5,7 +5,7 @@ import Header from './Header';
 import type { StateProps } from './Header';
 
 const mapStateToProps = (state: StoreState): StateProps => ({
-  gps: state.app.gps
+  gps: state.gps
 });
 
 export default connect(mapStateToProps, null)(Header);

--- a/src/components/Base/ManualGPSModal/index.js
+++ b/src/components/Base/ManualGPSModal/index.js
@@ -4,8 +4,8 @@ import type { Dispatch } from 'redux';
 import ManualGPSModal from './ManualGPSModal';
 
 const mapStateToProps = state => ({
-  visible: state.app.modals.manualGPS,
-  gpsStatus: state.app.gps.status
+  visible: state.modals.manualGPS,
+  gpsStatus: state.gps.status
 });
 
 export default connect(mapStateToProps)(ManualGPSModal);

--- a/src/components/Base/SavedModal/index.js
+++ b/src/components/Base/SavedModal/index.js
@@ -7,10 +7,10 @@ import { observationSelect } from '../../../ducks/observations';
 import { observationSource } from '../../../ducks/observationSource';
 
 const mapStateToProps = state => ({
-  selectedObservation: state.app.selectedObservation,
-  categories: state.app.categories,
-  gpsFormat: state.app.settings.gpsFormat,
-  icons: state.app.icons
+  selectedObservation: state.selectedObservation,
+  categories: state.categories,
+  gpsFormat: state.settings.gpsFormat,
+  icons: state.icons
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Base/Thumbnail/index.js
+++ b/src/components/Base/Thumbnail/index.js
@@ -7,7 +7,7 @@ import Thumbnail from './Thumbnail';
 
 const mapStateToProps = (state: StoreState, ownProps: Props) => {
   return {
-    attachment: state.app.attachments[ownProps.attachmentId]
+    attachment: state.attachments[ownProps.attachmentId]
   };
 };
 

--- a/src/components/Views/CameraView/CameraView.js
+++ b/src/components/Views/CameraView/CameraView.js
@@ -137,6 +137,7 @@ class CameraView extends React.Component<
           const initialObservation = applyObservationDefaults({
             id: size(observations) + 1
           });
+          console.log('updating source, creating, saving media')
           updateObservationSource();
           createObservation(initialObservation);
           saveMedia({ source: data.uri, generateThumbnail: true });

--- a/src/components/Views/CameraView/index.js
+++ b/src/components/Views/CameraView/index.js
@@ -14,9 +14,9 @@ import { drawerClose, drawerOpen } from '../../../ducks/drawers';
 
 function mapStateToProps(state: StoreState, ownProps: Props): StateProps {
   return {
-    observations: state.app.observations,
-    selectedObservation: state.app.selectedObservation,
-    showSavedModal: state.app.modals.saved,
+    observations: state.observations,
+    selectedObservation: state.selectedObservation,
+    showSavedModal: state.modals.saved,
     showEditorView:
       ownProps.navigation &&
       ownProps.navigation.state &&

--- a/src/components/Views/Categories/index.js
+++ b/src/components/Views/Categories/index.js
@@ -14,10 +14,10 @@ import Categories from './Categories';
 import type { StateProps } from './Categories';
 
 function mapStateToProps(state: StoreState): StateProps {
-  const categories = values(state.app.categories).sort(
+  const categories = values(state.categories).sort(
     (a, b) => a.name - b.name
   );
-  const { selectedObservation, observations } = state.app;
+  const { selectedObservation, observations } = state;
 
   let updateFlow = false;
   if (selectedObservation && observations[selectedObservation.id]) {
@@ -25,11 +25,11 @@ function mapStateToProps(state: StoreState): StateProps {
   }
 
   return {
-    allFields: state.app.fields,
+    allFields: state.fields,
     categories,
     selectedObservation,
     updateFlow,
-    icons: state.app.icons
+    icons: state.icons
   };
 }
 

--- a/src/components/Views/ManualGPS/index.js
+++ b/src/components/Views/ManualGPS/index.js
@@ -12,9 +12,9 @@ import { gpsFormatSettingsSet } from '../../../ducks/settings';
 import { modalShow } from '../../../ducks/modals';
 
 const mapStateToProps = (state: StoreState): StateProps => ({
-  gpsFormat: state.app.settings.gpsFormat,
-  selectedObservation: state.app.selectedObservation,
-  observationSource: state.app.observationSource.source
+  gpsFormat: state.settings.gpsFormat,
+  selectedObservation: state.selectedObservation,
+  observationSource: state.observationSource.source
 });
 
 const mapDispatchToProps = (dispatch: Dispatch): DispatchProps => ({

--- a/src/components/Views/MapView/Map/index.js
+++ b/src/components/Views/MapView/Map/index.js
@@ -14,10 +14,10 @@ import type { DispatchProps, StateProps } from './Map';
 import { styleList } from '../../../../ducks/map';
 
 const mapStateToProps = (state: StoreState): StateProps => ({
-  observations: state.app.observations,
-  selectedObservation: state.app.selectedObservation,
-  coords: state.app.gps.coords,
-  selectedStyle: state.app.map.selectedStyle
+  observations: state.observations,
+  selectedObservation: state.selectedObservation,
+  coords: state.gps.coords,
+  selectedStyle: state.map.selectedStyle
 });
 
 function mapDispatchToProps(dispatch: Dispatch): DispatchProps {

--- a/src/components/Views/MapView/index.js
+++ b/src/components/Views/MapView/index.js
@@ -6,7 +6,7 @@ import { drawerClose, drawerOpen } from '../../../ducks/drawers';
 import { observationList } from '../../../ducks/observations';
 
 const mapStateToProps = state => ({
-  showSavedModal: state.app.modals.saved
+  showSavedModal: state.modals.saved
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/components/Views/ObservationDetailView/index.js
+++ b/src/components/Views/ObservationDetailView/index.js
@@ -12,10 +12,10 @@ import type { StateProps, DispatchProps } from './ObservationDetailView';
 
 function mapStateToProps(state: StoreState): StateProps {
   return {
-    selectedObservation: state.app.selectedObservation,
-    categories: state.app.categories,
-    gpsFormat: state.app.settings.gpsFormat,
-    icons: state.app.icons
+    selectedObservation: state.selectedObservation,
+    categories: state.categories,
+    gpsFormat: state.settings.gpsFormat,
+    icons: state.icons
   };
 }
 

--- a/src/components/Views/ObservationEditor/index.js
+++ b/src/components/Views/ObservationEditor/index.js
@@ -15,26 +15,26 @@ import ObservationEditor from './ObservationEditor';
 import type { Props, StateProps, DispatchProps } from './ObservationEditor';
 
 function mapStateToProps(state: StoreState, ownProps: Props): StateProps {
-  const category = state.app.selectedObservation
-    ? state.app.categories[state.app.selectedObservation.categoryId]
+  const category = state.selectedObservation
+    ? state.categories[state.selectedObservation.categoryId]
     : undefined;
 
   return {
     category:
-      (state.app.categories &&
+      (state.categories &&
         ownProps.navigation.state &&
         ownProps.navigation.state.params &&
         ownProps.navigation.state.params.category &&
-        state.app.categories[ownProps.navigation.state.params.category]) ||
+        state.categories[ownProps.navigation.state.params.category]) ||
       category,
-    selectedObservation: state.app.selectedObservation,
-    observations: values(state.app.observations),
-    observationSource: state.app.observationSource.source,
-    cancelModalVisible: state.app.modals.cancelled,
-    gps: state.app.gps,
-    manualGPSModalVisible: state.app.modals.manualGPS,
-    gpsFormat: state.app.settings.gpsFormat,
-    icons: state.app.icons
+    selectedObservation: state.selectedObservation,
+    observations: values(state.observations),
+    observationSource: state.observationSource.source,
+    cancelModalVisible: state.modals.cancelled,
+    gps: state.gps,
+    manualGPSModalVisible: state.modals.manualGPS,
+    gpsFormat: state.settings.gpsFormat,
+    icons: state.icons
   };
 }
 

--- a/src/components/Views/ObservationFields/index.js
+++ b/src/components/Views/ObservationFields/index.js
@@ -9,8 +9,8 @@ import type { Props, StateProps, DispatchProps } from './ObservationFields';
 
 function mapStateToProps(state: StoreState): StateProps {
   return {
-    allFields: state.app.fields,
-    selectedObservation: state.app.selectedObservation
+    allFields: state.fields,
+    selectedObservation: state.selectedObservation
   };
 }
 

--- a/src/components/Views/ObservationsView/index.js
+++ b/src/components/Views/ObservationsView/index.js
@@ -16,16 +16,16 @@ import ObservationsView from './ObservationsView';
 import type { StateProps, DispatchProps } from './ObservationsView';
 
 function mapStateToProps(state: StoreState): StateProps {
-  const observations = values(state.app.observations).sort(
+  const observations = values(state.observations).sort(
     (a, b) => new Date(b.created) - new Date(a.created)
   );
-  const drawerOpened = state.app.drawers.observations;
+  const drawerOpened = state.drawers.observations;
   return {
     drawerOpened,
     observations,
-    categories: state.app.categories,
-    icons: state.app.icons,
-    resizedImages: state.app.resizedImages
+    categories: state.categories,
+    icons: state.icons,
+    resizedImages: state.resizedImages
   };
 }
 

--- a/src/components/Views/PhotoView/index.js
+++ b/src/components/Views/PhotoView/index.js
@@ -11,8 +11,8 @@ function mapStateToProps(state: StoreState, ownProps: Props): StateProps {
   const id = ownProps.navigation.getParam('photoId', '');
 
   return {
-    selectedObservation: state.app.selectedObservation,
-    attachment: id ? state.app.attachments[id] : undefined
+    selectedObservation: state.selectedObservation,
+    attachment: id ? state.attachments[id] : undefined
   };
 }
 

--- a/src/components/Views/SettingsView/index.js
+++ b/src/components/Views/SettingsView/index.js
@@ -9,9 +9,9 @@ import { styleSelect, styleList } from '../../../ducks/map';
 
 function mapStateToProps(state: StoreState): StateProps {
   return {
-    gpsFormat: state.app.settings.gpsFormat,
-    selectedStyle: state.app.map.selectedStyle,
-    styles: state.app.map.styles
+    gpsFormat: state.settings.gpsFormat,
+    selectedStyle: state.map.selectedStyle,
+    styles: state.map.styles
   };
 }
 

--- a/src/components/Views/SyncView/index.js
+++ b/src/components/Views/SyncView/index.js
@@ -17,9 +17,9 @@ import type { StateProps, DispatchProps } from './SyncView';
 
 function mapStateToProps(state: StoreState): StateProps {
   return {
-    devices: values(state.app.devices),
-    selectedDevice: state.app.selectedDevice,
-    syncedModalVisible: state.app.modals.synced
+    devices: values(state.devices),
+    selectedDevice: state.selectedDevice,
+    syncedModalVisible: state.modals.synced
   };
 }
 

--- a/src/ducks/index.js
+++ b/src/ducks/index.js
@@ -13,20 +13,18 @@ import settings from './settings';
 import map from './map';
 import media from './media';
 
-const rootReducer = combineReducers({
-  app: appCombineReducers(
-    ...categories,
-    ...devices,
-    ...drawers,
-    ...fields,
-    ...observationSource,
-    ...settings,
-    ...gps,
-    ...modals,
-    ...observations,
-    ...map,
-    ...media
-  )
-});
+const rootReducer = appCombineReducers(
+  ...categories,
+  ...devices,
+  ...drawers,
+  ...fields,
+  ...observationSource,
+  ...settings,
+  ...gps,
+  ...modals,
+  ...observations,
+  ...map,
+  ...media
+)
 
 export default rootReducer;

--- a/src/ducks/media.js
+++ b/src/ducks/media.js
@@ -1,7 +1,7 @@
 // @flow
 import update from 'immutability-helper';
 import { create } from '../lib/redux';
-import type { StoreState, AppStoreState } from '../types/redux';
+import type { StoreState } from '../types/redux';
 import { lookup } from 'mime-types';
 import {
   resourcePending,

--- a/src/ducks/observations.js
+++ b/src/ducks/observations.js
@@ -167,7 +167,7 @@ export const {
 });
 
 export const selectObservation = createSelector(
-  [(state: StoreState, id: string): Observation => state.app.observations[id]],
+  [(state: StoreState, id: string): Observation => state.observations[id]],
   (observation: Observation): Observation => observation,
   (observation: Observation, id: string): string => id
 );

--- a/src/epics/media.js
+++ b/src/epics/media.js
@@ -37,7 +37,7 @@ export const mediaLoadingEpic = (
           })
         : Media.backup(source);
       const { mediaId, observation } = action.meta;
-      const observationId = store.getState().app.attachments[mediaId]
+      const observationId = store.getState().attachments[mediaId]
         .observation;
       const meta = {
         observationId: observation,
@@ -84,9 +84,9 @@ export const mediaSaveEpic = (
       const type = lookup(meta.source) || '';
       const observation = meta.observationId || 'selected';
 
-      let updatedObservation = store.getState().app.selectedObservation;
+      let updatedObservation = store.getState().selectedObservation;
       if (meta.observationId) {
-        updatedObservation = store.getState().app.observations[
+        updatedObservation = store.getState().observations[
           meta.observationId
         ];
       }

--- a/src/epics/observations.js
+++ b/src/epics/observations.js
@@ -42,11 +42,11 @@ export const observationSaveEpic = (
     .ofType(OBSERVATION_SAVE)
     .filter(
       action =>
-        action.status === 'Start' && !!store.getState().app.selectedObservation
+        action.status === 'Start' && !!store.getState().selectedObservation
     )
     .flatMap(action => {
       return Observation.create(
-        store.getState().app.selectedObservation
+        store.getState().selectedObservation
       ).flatMap(observation =>
         Observable.merge(
           Observable.of(observationSave(action.meta, observation)),
@@ -64,12 +64,12 @@ export const observationUpdateSaveEpic = (
     .filter(
       action =>
         action.status === 'Start' &&
-        ((!action.meta && !!store.getState().app.selectedObservation) ||
+        ((!action.meta && !!store.getState().selectedObservation) ||
           action.meta)
     )
     .flatMap(action =>
       Observation.update(
-        action.meta || store.getState().app.selectedObservation
+        action.meta || store.getState().selectedObservation
       ).map(observation => observationUpdateSave(action.meta, observation))
     );
 

--- a/src/lib/media.js
+++ b/src/lib/media.js
@@ -1,7 +1,7 @@
 // @flow
 import { CameraRoll } from 'react-native';
 import { Observable } from 'rxjs';
-import * as ImageResizer from 'react-native-image-resizer';
+import ImageResizer from 'react-native-image-resizer';
 
 type MediaType = 'photo' | 'video';
 
@@ -15,7 +15,7 @@ export const saveToCameraRoll = (uri: string, type: MediaType) => {
 
 export const generateThumbnail = (uri: string) => {
   return Observable.from(
-    ImageResizer.default.createResizedImage(uri, 300, 300, 'JPEG', 50)
+    ImageResizer.createResizedImage(uri, 300, 300, 'JPEG', 50)
   );
 };
 

--- a/src/lib/redux.js
+++ b/src/lib/redux.js
@@ -1,5 +1,5 @@
 // @flow
-import { AppStoreState, Action } from '../types/redux';
+import { StoreState, Action } from '../types/redux';
 import type { Reducers } from '../types/redux';
 import { createInitialStore } from './store';
 
@@ -9,7 +9,7 @@ export function create<M, P>(
 ): {
   type: string,
   action: (meta: M, payload?: P | Error) => Action<M, P>,
-  reducer: (state: AppStoreState, action: Action<M, P>) => AppStoreState
+  reducer: (state: StoreState, action: Action<M, P>) => StoreState
 } {
   return {
     type,
@@ -31,7 +31,7 @@ export function create<M, P>(
         payload
       };
     },
-    reducer: (state: AppStoreState, action: Action<M, P>) => {
+    reducer: (state: StoreState, action: Action<M, P>) => {
       if (action.type === type) {
         switch (action.status) {
           case 'Start':
@@ -61,7 +61,7 @@ export function create<M, P>(
 }
 
 export const combineReducers = (...reducers: Function[]): Function => (
-  state: AppStoreState,
+  state: StoreState,
   action: Action<any, any>
 ) => {
   let newState = state;

--- a/src/lib/store.js
+++ b/src/lib/store.js
@@ -1,7 +1,7 @@
 import { createStore, applyMiddleware } from 'redux';
 import { persistStore, persistReducer } from 'redux-persist';
 import storage from 'redux-persist/lib/storage';
-import autoMergeLevel2 from 'redux-persist/lib/stateReconciler/autoMergeLevel2';
+import autoMergeLevel1 from 'redux-persist/lib/stateReconciler/autoMergeLevel1';
 import { createEpicMiddleware } from 'redux-observable';
 import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import rootEpic from '../epics';
@@ -11,10 +11,10 @@ const epicMiddleware = createEpicMiddleware(rootEpic);
 
 const persistConfig = {
   key: 'root',
-  version: 1,
+  version: 2,
   storage,
   whitelist: ['settings', 'modals', 'drawers', 'map'],
-  stateReconciler: autoMergeLevel2 // see "Merge Process" section for details.
+  stateReconciler: autoMergeLevel1 // see "Merge Process" section for details.
 };
 
 export function configureStore() {

--- a/src/types/gps.js
+++ b/src/types/gps.js
@@ -10,11 +10,11 @@ import {
 export type GPSFormat = 'DD' | 'DDM' | 'DMS' | 'UTM';
 
 export type GPSStatus =
-  | PERMISSION_DENIED
-  | UNAVAILABLE
-  | SEARCHING
-  | LOW_ACCURACY
-  | HIGH_ACCURACY;
+  | 'PERMISSION_DENIED'
+  | 'UNAVAILABLE'
+  | 'SEARCHING'
+  | 'LOW_ACCURACY'
+  | 'HIGH_ACCURACY';
 
 export type Coordinates = {
   longitude: number,

--- a/src/types/redux.js
+++ b/src/types/redux.js
@@ -9,7 +9,7 @@ import type { ObservationSourceState } from './observationSource';
 import type { Device } from './device';
 import type { MapState } from './map';
 
-export interface AppStoreState {
+export interface StoreState {
   observations: {
     [id: string]: Observation
   };
@@ -57,12 +57,6 @@ export type SettingsState = {
   gpsFormat: GPSFormat
 };
 
-export interface StoreState {
-  app: AppStoreState;
-
-  mainStack: any;
-}
-
 export type ActionStatus = 'Start' | 'Error' | 'Success';
 
 export interface Action<M, P> {
@@ -74,9 +68,9 @@ export interface Action<M, P> {
 }
 
 export type Reducers = {
-  start?: (state: AppStoreState, meta: any) => AppStoreState,
-  success?: (state: AppStoreState, meta: any, payload: any) => AppStoreState,
-  error?: (state: AppStoreState, meta: any, error: Error) => AppStoreState
+  start?: (state: StoreState, meta: any) => StoreState,
+  success?: (state: StoreState, meta: any, payload: any) => StoreState,
+  error?: (state: StoreState, meta: any, error: Error) => StoreState
 };
 
 export type ResourceStatus = 'Pending' | 'Success' | 'Failed';


### PR DESCRIPTION
Previously the state was all under a prop, app.
This made it hard to whitelist or blacklist props for redux-persist.
Redux-persist was overwriting the GPS status, because the GPS is called outside the persist gate.
With larger preset files with complex svgs, persisting the entire state synchronously was causing perf issues