### PR TITLE
Update observations to go under properties

### DIFF
--- a/src/api/observations.js
+++ b/src/api/observations.js
@@ -37,6 +37,8 @@ class Observation {
       route: `/observations/${observation.id}`,
       body: {
         id: observation.id,
+        lat: observation.lat || undefined,
+        lon: observation.lon || undefined,
         properties: observation
       }
     }).map(applyObservationDefaults);

--- a/src/api/observations.js
+++ b/src/api/observations.js
@@ -24,19 +24,22 @@ class Observation {
       method: 'POST',
       route: '/observations',
       body: {
+        lat: observation.lat,
+        lon: observation.lon,
         device_id: '1',
-        ...observation
+        properties: observation
       }
-    });
+    }).map(applyObservationDefaults);
 
   static update = (observation: UpdateRequest) =>
     jsonRequest({
       method: 'PUT',
       route: `/observations/${observation.id}`,
       body: {
-        ...observation
+        id: observation.id,
+        properties: observation
       }
-    });
+    }).map(applyObservationDefaults);
 }
 
 export default Observation;

--- a/src/components/Views/CameraView/CameraView.js
+++ b/src/components/Views/CameraView/CameraView.js
@@ -23,7 +23,7 @@ import { CHARCOAL, WHITE } from '../../../lib/styles.js';
 
 import ObservationsView from '../ObservationsView';
 import AddButton from '../../../images/add-button.png';
-import { applyObservationDefaults } from '../../../models/observations';
+import { emptyObservation } from '../../../models/observations';
 import Header from '../../Base/Header';
 import SavedModal from '../../Base/SavedModal';
 import type { MediaSaveMeta } from '../../../ducks/media';
@@ -125,9 +125,9 @@ class CameraView extends React.Component<
           navigation.navigate({
             routeName: 'Categories'
           });
-          const initialObservation = applyObservationDefaults({
-            id: size(observations) + 1
-          });
+          const initialObservation = emptyObservation(
+            (size(observations) + 1).toString()
+          );
           console.log('updating source, creating, saving media');
           updateObservationSource();
           createObservation(initialObservation);

--- a/src/components/Views/MapView/Map/Map.js
+++ b/src/components/Views/MapView/Map/Map.js
@@ -19,7 +19,7 @@ import env from '../../../../../env.json';
 import AddButton from '../../../../images/add-button.png';
 import Gradient from '../../../../images/gradient-overlay.png';
 import { WHITE } from '../../../../lib/styles';
-import { applyObservationDefaults } from '../../../../models/observations';
+import { emptyObservation } from '../../../../models/observations';
 import type { Coordinates } from '../../../../types/gps';
 import type { Style } from '../../../../types/map';
 
@@ -129,9 +129,9 @@ class Map extends React.Component<Props & StateProps & DispatchProps> {
       selectedStyle,
       navigation
     } = this.props;
-    const initialObservation = applyObservationDefaults({
-      id: size(observations) + 1
-    });
+    const initialObservation = emptyObservation(
+      (size(observations) + 1).toString()
+    );
 
     navigation.navigate({
       routeName: 'Categories',
@@ -158,11 +158,11 @@ class Map extends React.Component<Props & StateProps & DispatchProps> {
       observations,
       updateObservationSource
     } = this.props;
-    const initialObservation = applyObservationDefaults({
-      id: size(observations) + 1,
-      lat: coordinates[1],
-      lon: coordinates[0]
-    });
+    const initialObservation = emptyObservation(
+      (size(observations) + 1).toString(),
+      coordinates[1],
+      coordinates[0]
+    );
 
     navigation.navigate({
       routeName: 'Categories',

--- a/src/components/Views/MapView/MapView.js
+++ b/src/components/Views/MapView/MapView.js
@@ -20,7 +20,6 @@ import type { CreateRequest, UpdateRequest } from '@api/observations';
 import env from '../../../../env.json';
 import AddButton from '../../../images/add-button.png';
 import Gradient from '../../../images/gradient-overlay.png';
-import { applyObservationDefaults } from '../../../models/observations';
 import type { GPSState } from '../../../types/gps';
 import CollectionsImg from 'react-native-vector-icons/MaterialIcons';
 import type { Observation } from '../../../types/observation';

--- a/src/models/observations.js
+++ b/src/models/observations.js
@@ -16,6 +16,6 @@ export const applyObservationDefaults = (partial: Object): Observation => ({
   ...partial.properties,
 
   id: partial.id,
-  lat: parseInt(partial.lat) || 0,
-  lon: parseInt(partial.lon) || 0
+  lat: parseFloat(partial.lat) || parseFloat(partial.properties.lat) || 0,
+  lon: parseFloat(partial.lon) || parseFloat(partial.properties.lon) || 0
 });

--- a/src/models/observations.js
+++ b/src/models/observations.js
@@ -3,8 +3,6 @@ import type { Observation } from '../types/observation';
 
 export const applyObservationDefaults = (partial: Object): Observation => ({
   type: 'Rios y corrientes',
-  lat: 0,
-  lon: 0,
   link: 'link',
   created: new Date(),
   name: '',
@@ -15,5 +13,9 @@ export const applyObservationDefaults = (partial: Object): Observation => ({
   categoryId: '0',
   fields: [],
 
-  ...partial
+  ...partial.properties,
+
+  id: partial.id,
+  lat: parseInt(partial.lat) || 0,
+  lon: parseInt(partial.lon) || 0
 });

--- a/src/models/observations.js
+++ b/src/models/observations.js
@@ -19,3 +19,19 @@ export const applyObservationDefaults = (partial: Object): Observation => ({
   lat: parseFloat(partial.lat) || parseFloat(partial.properties.lat) || 0,
   lon: parseFloat(partial.lon) || parseFloat(partial.properties.lon) || 0
 });
+
+export const emptyObservation = (id: string, lat?: string, lon?: string) => ({
+  type: 'Rios y corrientes',
+  link: 'link',
+  created: new Date(),
+  name: '',
+  notes: '',
+  observedBy: 'Tú',
+  attachments: [],
+  icon: null,
+  categoryId: '0',
+  fields: [],
+  id,
+  lat: lat || 0,
+  lon: lon || 0
+});


### PR DESCRIPTION
Quick hack fix, observations update endpoint only allows updates to lat, lon, and properties keys, so client will transform observation types when interacting with server