### PR TITLE
Do not update map center and zoom on re-render

### DIFF
--- a/src/components/Views/MapView/Map/Map.js
+++ b/src/components/Views/MapView/Map/Map.js
@@ -180,7 +180,11 @@ class Map extends React.Component<Props & StateProps & DispatchProps> {
     const { coords } = this.props;
 
     if (this.map && coords) {
-      this.map.moveTo([coords.longitude, coords.latitude], 200);
+      this.map.setCamera({
+        centerCoordinate: [coords.longitude, coords.latitude],
+        zoom: 13,
+        duration: 500
+      });
     }
   };
 
@@ -197,17 +201,7 @@ class Map extends React.Component<Props & StateProps & DispatchProps> {
         <View style={{ flex: 1 }}>
           <MapboxGL.MapView
             style={{ flex: 1 }}
-            centerCoordinate={
-              coords ? [coords.longitude, coords.latitude] : undefined
-            }
             ref={this.handleMapViewRef}
-            zoomLevel={
-              selectedStyle
-                ? Math.floor(
-                    (selectedStyle.minzoom + selectedStyle.maxzoom) / 2
-                  )
-                : 12
-            }
             minZoomLevel={selectedStyle ? selectedStyle.minzoom : undefined}
             maxZoomLevel={22}
             logoEnabled


### PR DESCRIPTION
This is a temporary fix until we have two modes for the map view: (1) follow location and (2) free movement.

Prior to this PR an update to the GPS coordinates caused the map to re-render, centering on the new coordinates with a fixed zoom level. When the GPS is actively updating (once every 1000ms) this made it impossible to actually move or zoom the map, it kept jumping back.

Now the map does not move at all with location updates. The user needs to press the "locate me" button in the bottom-right of the screen. The animation for the location-me has also been improved and zooms in further than previously.