### PR TITLE
fix: migrate media files from fs-blob-store to safe-fs-blob-store 

### DIFF
--- a/src/rnnodeapp/index.js
+++ b/src/rnnodeapp/index.js
@@ -51,13 +51,13 @@ console.log('2: dirs created');
 
 // Migrate media from old fs-blob-store, if needed
 migrateMedia(MEDIA_PATH, function (err) {
-  if (err) throw err;
+  if (err) console.error(err);
 })
 
 // Unpack styles and presets, if needed
 styles.unpackIfNew(STATIC_PATH, function(err, didWrite) {
   console.log('3: unpacked', err, didWrite);
-  if (err) throw err;
+  if (err) console.error(err);
 
   start();
 });

--- a/src/rnnodeapp/index.js
+++ b/src/rnnodeapp/index.js
@@ -52,18 +52,21 @@ console.log('2: dirs created');
 // Migrate media from old fs-blob-store, if needed
 migrateMedia(MEDIA_PATH, function (err) {
   if (err) console.error(err);
+  start();
 })
 
 // Unpack styles and presets, if needed
 styles.unpackIfNew(STATIC_PATH, function(err, didWrite) {
   console.log('3: unpacked', err, didWrite);
   if (err) console.error(err);
-
   start();
 });
 
 
+let pending = 2
 function start() {
+  pending--
+  if (pending !== 0) return
   console.log('4: starting');
   const db = osm(DB_PATH);
   const media = blobstore(MEDIA_PATH);

--- a/src/rnnodeapp/index.js
+++ b/src/rnnodeapp/index.js
@@ -27,6 +27,8 @@ const os = require('os');
 const mkdirp = require('mkdirp');
 const styles = require('mapeo-styles');
 
+const migrateMedia = require('./migrateMedia')
+
 console.log('1: init');
 
 // NOTE: in the future, we might want separate private keys
@@ -47,12 +49,19 @@ mkdirp.sync(MEDIA_PATH);
 mkdirp.sync(STATIC_PATH);
 console.log('2: dirs created');
 
+// Migrate media from old fs-blob-store, if needed
+migrateMedia(MEDIA_PATH, function (err) {
+  if (err) throw err;
+})
+
 // Unpack styles and presets, if needed
 styles.unpackIfNew(STATIC_PATH, function(err, didWrite) {
   console.log('3: unpacked', err, didWrite);
   if (err) throw err;
+
   start();
 });
+
 
 function start() {
   console.log('4: starting');

--- a/src/rnnodeapp/migrateMedia.js
+++ b/src/rnnodeapp/migrateMedia.js
@@ -1,5 +1,4 @@
 const path = require('path')
-const pump = require('pump')
 const parallel = require('run-parallel')
 const fs = require('fs')
 const safe = require('safe-fs-blob-store')
@@ -8,7 +7,7 @@ const safe = require('safe-fs-blob-store')
 // 1. see if original/media has files
 // 2. add each file to safe-fs-blob-store
 // 3. remove old file
-//
+
 module.exports = migrateDirectory
 
 function migrateDirectory (mediaPath, cb) {

--- a/src/rnnodeapp/migrateMedia.js
+++ b/src/rnnodeapp/migrateMedia.js
@@ -1,0 +1,42 @@
+const path = require('path')
+const pump = require('pump')
+const parallel = require('run-parallel')
+const fs = require('fs')
+const safe = require('safe-fs-blob-store')
+
+// migrate blob stores
+// 1. see if original/media has files
+// 2. add each file to safe-fs-blob-store
+// 3. remove old file
+//
+module.exports = migrateDirectory
+
+function migrateDirectory (mediaPath, cb) {
+  var blobstore = safe(mediaPath)
+  var tasks = []
+  fs.readdir(mediaPath, function (err, files) {
+    if (err) throw err
+    files.forEach(function (filename) {
+      tasks.push((next) => {
+        migrateFile(filename, next)
+      })
+    })
+    parallel(tasks, cb)
+  })
+
+  function migrateFile (key, cb) {
+    var filename = path.join(mediaPath, key)
+    fs.stat(filename, function (err, stat) {
+      if (err) return cb(err)
+      if (stat.isFile()) {
+        var cleanup = function (err) {
+          if (err) return cb(err)
+          fs.unlink(filename, cb)
+        }
+        var readStream = fs.createReadStream(filename)
+        var writeStream = blobstore.createWriteStream({key}, cleanup)
+        readStream.pipe(writeStream)
+      }
+    })
+  }
+}

--- a/src/rnnodeapp/migrateMedia.js
+++ b/src/rnnodeapp/migrateMedia.js
@@ -8,23 +8,35 @@ const safe = require('safe-fs-blob-store')
 // 2. add each file to safe-fs-blob-store
 // 3. remove old file
 
-module.exports = migrateDirectory
+module.exports = function (mediaPath, cb) {
+  migrateDirectory(path.join(mediaPath, 'original'), function (err) {
+    if (err) return cb(err)
+    migrateDirectory(path.join(mediaPath, 'thumbnail'), cb)
+  })
+}
 
-function migrateDirectory (mediaPath, cb) {
-  var blobstore = safe(mediaPath)
+function migrateDirectory (dir, cb) {
+  var blobstore = safe(dir)
   var tasks = []
-  fs.readdir(mediaPath, function (err, files) {
-    if (err) throw err
-    files.forEach(function (filename) {
-      tasks.push((next) => {
-        migrateFile(filename, next)
+  fs.stat(dir, function (err, stat) {
+    if (err) {
+      if (err.code === 'ENOENT') return cb(new Error(`Directory ${dir} does not exist.`))
+      else return cb(err)
+    }
+
+    fs.readdir(dir, function (err, files) {
+      if (err) return cb(err)
+      files.forEach(function (filename) {
+        tasks.push((next) => {
+          migrateFile(filename, next)
+        })
       })
+      parallel(tasks, cb)
     })
-    parallel(tasks, cb)
   })
 
   function migrateFile (key, cb) {
-    var filename = path.join(mediaPath, key)
+    var filename = path.join(dir, key)
     fs.stat(filename, function (err, stat) {
       if (err) return cb(err)
       if (stat.isFile()) {
@@ -33,7 +45,8 @@ function migrateDirectory (mediaPath, cb) {
           fs.unlink(filename, cb)
         }
         var readStream = fs.createReadStream(filename)
-        var writeStream = blobstore.createWriteStream({key}, cleanup)
+        var keyWithPrefix = `${path.dirname(key).split('/').pop()}/${key}`
+        var writeStream = blobstore.createWriteStream({key: keyWithPrefix}, cleanup)
         readStream.pipe(writeStream)
       }
     })

--- a/src/rnnodeapp/migrateMedia.js
+++ b/src/rnnodeapp/migrateMedia.js
@@ -48,7 +48,7 @@ function migrateDirectory (dir, cb) {
         var keyWithPrefix = `${path.dirname(key).split('/').pop()}/${key}`
         var writeStream = blobstore.createWriteStream({key: keyWithPrefix}, cleanup)
         readStream.pipe(writeStream)
-      }
+      } else cb()
     })
   }
 }

--- a/src/rnnodeapp/package-lock.json
+++ b/src/rnnodeapp/package-lock.json
@@ -2310,15 +2310,6 @@
         "looper": "2.0.0"
       }
     },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
-      }
-    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",

--- a/src/rnnodeapp/package-lock.json
+++ b/src/rnnodeapp/package-lock.json
@@ -9,11 +9,11 @@
       "resolved": "https://registry.npmjs.org/@digidem/atomic-fs-blob-store/-/atomic-fs-blob-store-5.3.0.tgz",
       "integrity": "sha512-Eoq0Owk4I6CEYuRY1egKNkS0kYqW/JUzkwlnK1mbLCrfd+swnV/UH9o/OVgd4LCcSjR7rZSrK/Pn6hPRJMQMLw==",
       "requires": {
-        "@digidem/fs-write-stream-atomic": "^1.1.0",
-        "duplexify": "^3.2.0",
-        "end-of-stream": "^1.0.0",
-        "lru-cache": "^2.5.0",
-        "mkdirp": "^0.5.0"
+        "@digidem/fs-write-stream-atomic": "1.1.0",
+        "duplexify": "3.6.0",
+        "end-of-stream": "1.4.1",
+        "lru-cache": "2.7.3",
+        "mkdirp": "0.5.1"
       }
     },
     "@digidem/fs-write-stream-atomic": {
@@ -21,10 +21,10 @@
       "resolved": "https://registry.npmjs.org/@digidem/fs-write-stream-atomic/-/fs-write-stream-atomic-1.1.0.tgz",
       "integrity": "sha512-VzcduOqQf1IeZItO24dJFOiJpkue5JTvL1SK6jA8b40H0URtTKsQES7fmnU9BJdlY4IyEdolPlsa84hx5quemQ==",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "iferr": "^0.1.5",
-        "imurmurhash": "^0.1.4",
-        "readable-stream": "1 || 2"
+        "graceful-fs": "4.1.11",
+        "iferr": "0.1.5",
+        "imurmurhash": "0.1.4",
+        "readable-stream": "2.3.6"
       }
     },
     "abbrev": {
@@ -37,7 +37,7 @@
       "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-3.0.0.tgz",
       "integrity": "sha512-KUWx9UWGQD12zsmLNj64/pndaz4iJh/Pj7nopgkfDG6RlCcbMZvT6+9l7dchK4idog2Is8VdC/PvNbFuFmalIQ==",
       "requires": {
-        "xtend": "~4.0.0"
+        "xtend": "4.0.1"
       }
     },
     "acorn": {
@@ -50,7 +50,7 @@
       "resolved": "https://registry.npmjs.org/after-all/-/after-all-2.0.2.tgz",
       "integrity": "sha1-IDACmO1glLTIXJjnyK1NymKPn3M=",
       "requires": {
-        "once": "^1.3.0"
+        "once": "1.4.0"
       }
     },
     "ajv": {
@@ -58,10 +58,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "co": "4.6.0",
+        "fast-deep-equal": "1.1.0",
+        "fast-json-stable-stringify": "2.0.0",
+        "json-schema-traverse": "0.3.1"
       }
     },
     "almost-equal": {
@@ -84,8 +84,8 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "requires": {
-        "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "array-flatten": {
@@ -98,13 +98,13 @@
       "resolved": "https://registry.npmjs.org/asar/-/asar-0.14.3.tgz",
       "integrity": "sha512-+hNnVVDmYbv05We/a9knj/98w171+A94A9DNHj+3kXUr3ENTQoSEcfbJRvBBRHyOh4vukBYWujmHvvaMmQoQbg==",
       "requires": {
-        "chromium-pickle-js": "^0.2.0",
-        "commander": "^2.9.0",
-        "cuint": "^0.2.1",
-        "glob": "^6.0.4",
-        "minimatch": "^3.0.3",
-        "mkdirp": "^0.5.0",
-        "mksnapshot": "^0.3.0",
+        "chromium-pickle-js": "0.2.0",
+        "commander": "2.16.0",
+        "cuint": "0.2.2",
+        "glob": "6.0.4",
+        "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
+        "mksnapshot": "0.3.1",
         "tmp": "0.0.28"
       }
     },
@@ -123,7 +123,7 @@
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
       "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "4.17.10"
       }
     },
     "async-limiter": {
@@ -156,7 +156,7 @@
       "resolved": "https://registry.npmjs.org/base-convertor/-/base-convertor-1.1.0.tgz",
       "integrity": "sha1-I98KcGPhxo+yT0Dt8y++XTKxwwM=",
       "requires": {
-        "big-integer": "^1.6.12"
+        "big-integer": "1.6.31"
       }
     },
     "bcrypt-pbkdf": {
@@ -165,7 +165,7 @@
       "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "optional": true,
       "requires": {
-        "tweetnacl": "^0.14.3"
+        "tweetnacl": "0.14.5"
       }
     },
     "big-integer": {
@@ -178,8 +178,8 @@
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
       "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
       "requires": {
-        "buffers": "~0.1.1",
-        "chainsaw": "~0.1.0"
+        "buffers": "0.1.1",
+        "chainsaw": "0.1.0"
       }
     },
     "bindings": {
@@ -197,8 +197,8 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
       "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
       "requires": {
-        "readable-stream": "^2.3.5",
-        "safe-buffer": "^5.1.1"
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2"
       }
     },
     "blob-store-replication-stream": {
@@ -206,10 +206,10 @@
       "resolved": "https://registry.npmjs.org/blob-store-replication-stream/-/blob-store-replication-stream-1.1.1.tgz",
       "integrity": "sha512-ttpAvPjcWRWeA0D2bFbSzWKIr57nIoNCd76KQHvzjjv9DUYd/dalz/wCXVW6xqOkaWFXoEVZNJwcvtb2Hnwbnw==",
       "requires": {
-        "collect-stream": "^1.2.1",
-        "debug": "^3.1.0",
-        "duplexify": "^3.5.1",
-        "length-prefixed-stream": "^1.5.1"
+        "collect-stream": "1.2.1",
+        "debug": "3.1.0",
+        "duplexify": "3.6.0",
+        "length-prefixed-stream": "1.6.0"
       }
     },
     "body": {
@@ -217,10 +217,10 @@
       "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
       "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
       "requires": {
-        "continuable-cache": "^0.3.1",
-        "error": "^7.0.0",
-        "raw-body": "~1.1.0",
-        "safe-json-parse": "~1.0.1"
+        "continuable-cache": "0.3.1",
+        "error": "7.0.2",
+        "raw-body": "1.1.7",
+        "safe-json-parse": "1.0.1"
       }
     },
     "bonjour": {
@@ -228,12 +228,12 @@
       "resolved": "https://registry.npmjs.org/bonjour/-/bonjour-3.5.0.tgz",
       "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
       "requires": {
-        "array-flatten": "^2.1.0",
-        "deep-equal": "^1.0.1",
-        "dns-equal": "^1.0.0",
-        "dns-txt": "^2.0.2",
-        "multicast-dns": "^6.0.1",
-        "multicast-dns-service-types": "^1.1.0"
+        "array-flatten": "2.1.1",
+        "deep-equal": "1.0.1",
+        "dns-equal": "1.0.0",
+        "dns-txt": "2.0.2",
+        "multicast-dns": "6.2.3",
+        "multicast-dns-service-types": "1.1.0"
       }
     },
     "bounding-box-overlap-test": {
@@ -246,7 +246,7 @@
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "requires": {
-        "balanced-match": "^1.0.0",
+        "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -255,10 +255,10 @@
       "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.6.1.tgz",
       "integrity": "sha512-OfZpABRQQf+Xsmju8XE9bDjs+uU4vLREGolP7bDgcpsI17QREyZ4Bl+2KLxxx1kCgA0fAIhKQBaBYh+PEcCqYQ==",
       "requires": {
-        "quote-stream": "^1.0.1",
-        "resolve": "^1.1.5",
-        "static-module": "^2.2.0",
-        "through2": "^2.0.0"
+        "quote-stream": "1.0.2",
+        "resolve": "1.8.1",
+        "static-module": "2.2.5",
+        "through2": "2.0.3"
       }
     },
     "browser-fingerprint": {
@@ -271,8 +271,8 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
       "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
@@ -310,9 +310,9 @@
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-3.0.5.tgz",
       "integrity": "sha512-0fUEthLqfCkYspEuP0vmiAe+PsXslE+AlILb2rmS9I4tAdm3SmpCI69M66zQL20GQEszdbXyVN6q+cpG/yhYlg==",
       "requires": {
-        "bindings": "~1.3.0",
-        "nan": "~2.10.0",
-        "prebuild-install": "~4.0.0"
+        "bindings": "1.3.0",
+        "nan": "2.10.0",
+        "prebuild-install": "4.0.0"
       }
     },
     "bytes": {
@@ -325,8 +325,8 @@
       "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
       "integrity": "sha1-HRPL/3F65xWAlKqIGzXQgbOHJT4=",
       "requires": {
-        "bytewise-core": "^1.2.2",
-        "typewise": "^1.0.3"
+        "bytewise-core": "1.2.3",
+        "typewise": "1.0.3"
       }
     },
     "bytewise-core": {
@@ -334,7 +334,7 @@
       "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
       "integrity": "sha1-P7QQx+kVWOsasiqCg0V3qmvWHUI=",
       "requires": {
-        "typewise-core": "^1.2"
+        "typewise-core": "1.2.0"
       }
     },
     "caseless": {
@@ -347,7 +347,7 @@
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
       "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
       "requires": {
-        "traverse": ">=0.3.0 <0.4"
+        "traverse": "0.3.9"
       }
     },
     "chownr": {
@@ -375,8 +375,8 @@
       "resolved": "https://registry.npmjs.org/collect-stream/-/collect-stream-1.2.1.tgz",
       "integrity": "sha1-gptBdGQxseJ+AebNPQrBY8IqHKc=",
       "requires": {
-        "concat-stream": "^1.2.0",
-        "once": "^1.3.0"
+        "concat-stream": "1.6.2",
+        "once": "1.4.0"
       }
     },
     "combined-stream": {
@@ -384,7 +384,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "~1.0.0"
+        "delayed-stream": "1.0.0"
       }
     },
     "commander": {
@@ -397,7 +397,7 @@
       "resolved": "https://registry.npmjs.org/comparable-storable-types/-/comparable-storable-types-1.0.0.tgz",
       "integrity": "sha1-EgkFmpzsz26ZSQ+KT6L/Vth8E3s=",
       "requires": {
-        "almost-equal": "^1.0.0"
+        "almost-equal": "1.1.0"
       }
     },
     "concat-map": {
@@ -410,10 +410,10 @@
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
+        "buffer-from": "1.1.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "typedarray": "0.0.6"
       }
     },
     "console-control-strings": {
@@ -447,7 +447,7 @@
       "integrity": "sha1-S4deCWm612T37AcGz0T1+wgx9rc=",
       "requires": {
         "browser-fingerprint": "0.0.1",
-        "core-js": "^1.1.1",
+        "core-js": "1.2.7",
         "node-fingerprint": "0.0.2"
       }
     },
@@ -461,7 +461,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "debug": {
@@ -477,7 +477,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "1.0.0"
       }
     },
     "decompress-zip": {
@@ -485,12 +485,12 @@
       "resolved": "https://registry.npmjs.org/decompress-zip/-/decompress-zip-0.3.0.tgz",
       "integrity": "sha1-rjvLfjTGWHmt/nfhnDD4ZgK0vbA=",
       "requires": {
-        "binary": "^0.3.0",
-        "graceful-fs": "^4.1.3",
-        "mkpath": "^0.1.0",
-        "nopt": "^3.0.1",
-        "q": "^1.1.2",
-        "readable-stream": "^1.1.8",
+        "binary": "0.3.0",
+        "graceful-fs": "4.1.11",
+        "mkpath": "0.1.0",
+        "nopt": "3.0.6",
+        "q": "1.5.1",
+        "readable-stream": "1.1.14",
         "touch": "0.0.3"
       },
       "dependencies": {
@@ -504,10 +504,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -537,7 +537,7 @@
       "resolved": "https://registry.npmjs.org/deferred-chunk-store/-/deferred-chunk-store-1.0.1.tgz",
       "integrity": "sha1-rjeqMqSh1tijAfHuybk3eOFsazM=",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "deferred-leveldown": {
@@ -545,7 +545,7 @@
       "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-1.2.2.tgz",
       "integrity": "sha512-uukrWD2bguRtXilKt6cAWKyoXrTSMo5m7crUdLfWQmu8kIm88w3QZoUL+6nhpfKVmhHANER6Re3sKoNoZ3IKMA==",
       "requires": {
-        "abstract-leveldown": "~2.6.0"
+        "abstract-leveldown": "2.6.3"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -553,7 +553,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
           "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         }
       }
@@ -563,8 +563,8 @@
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
       "requires": {
-        "foreach": "^2.0.5",
-        "object-keys": "^1.0.8"
+        "foreach": "2.0.5",
+        "object-keys": "1.0.12"
       }
     },
     "defined": {
@@ -597,8 +597,8 @@
       "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-1.3.1.tgz",
       "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
       "requires": {
-        "ip": "^1.1.0",
-        "safe-buffer": "^5.0.1"
+        "ip": "1.1.5",
+        "safe-buffer": "5.1.2"
       }
     },
     "dns-txt": {
@@ -606,7 +606,7 @@
       "resolved": "https://registry.npmjs.org/dns-txt/-/dns-txt-2.0.2.tgz",
       "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
       "requires": {
-        "buffer-indexof": "^1.0.0"
+        "buffer-indexof": "1.1.1"
       }
     },
     "duplexer2": {
@@ -614,7 +614,7 @@
       "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
       "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "duplexify": {
@@ -622,10 +622,10 @@
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
       "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "requires": {
-        "end-of-stream": "^1.0.0",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0",
-        "stream-shift": "^1.0.0"
+        "end-of-stream": "1.4.1",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "stream-shift": "1.0.0"
       }
     },
     "ecc-jsbn": {
@@ -634,7 +634,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "~0.1.0"
+        "jsbn": "0.1.1"
       }
     },
     "ecstatic": {
@@ -642,10 +642,10 @@
       "resolved": "https://registry.npmjs.org/ecstatic/-/ecstatic-3.2.1.tgz",
       "integrity": "sha512-BAdHx9LOCG1fwxY8MIydUBskl8UUQrYeC3WE14FA1DPlBzqoG1aOgEkypcSpmiiel8RAj8gW1s40RrclfrpGUg==",
       "requires": {
-        "he": "^1.1.1",
-        "mime": "^1.6.0",
-        "minimist": "^1.1.0",
-        "url-join": "^2.0.5"
+        "he": "1.1.1",
+        "mime": "1.6.0",
+        "minimist": "1.2.0",
+        "url-join": "2.0.5"
       }
     },
     "end-of-stream": {
@@ -653,7 +653,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
       "requires": {
-        "once": "^1.4.0"
+        "once": "1.4.0"
       }
     },
     "errno": {
@@ -661,7 +661,7 @@
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
       "requires": {
-        "prr": "~1.0.1"
+        "prr": "1.0.1"
       }
     },
     "error": {
@@ -669,8 +669,8 @@
       "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
       "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
       "requires": {
-        "string-template": "~0.2.1",
-        "xtend": "~4.0.0"
+        "string-template": "0.2.1",
+        "xtend": "4.0.1"
       }
     },
     "es-abstract": {
@@ -678,11 +678,11 @@
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
       "requires": {
-        "es-to-primitive": "^1.1.1",
-        "function-bind": "^1.1.1",
-        "has": "^1.0.1",
-        "is-callable": "^1.1.3",
-        "is-regex": "^1.0.4"
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.3",
+        "is-callable": "1.1.4",
+        "is-regex": "1.0.4"
       }
     },
     "es-to-primitive": {
@@ -690,9 +690,9 @@
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
       "requires": {
-        "is-callable": "^1.1.1",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.1"
+        "is-callable": "1.1.4",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
       }
     },
     "escodegen": {
@@ -700,11 +700,11 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
       "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
       "requires": {
-        "esprima": "^3.1.3",
-        "estraverse": "^4.2.0",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "optionator": "0.8.2",
+        "source-map": "0.6.1"
       }
     },
     "esprima": {
@@ -742,10 +742,10 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
       "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "requires": {
-        "acorn": "^5.0.0",
-        "foreach": "^2.0.5",
+        "acorn": "5.7.1",
+        "foreach": "2.0.5",
         "isarray": "0.0.1",
-        "object-keys": "^1.0.6"
+        "object-keys": "1.0.12"
       },
       "dependencies": {
         "isarray": {
@@ -780,8 +780,8 @@
       "resolved": "https://registry.npmjs.org/fd-chunk-store/-/fd-chunk-store-2.0.0.tgz",
       "integrity": "sha1-MuECTMhXNHB7EsVMBJj+Q2iGljc=",
       "requires": {
-        "defined": "^1.0.0",
-        "inherits": "^2.0.1"
+        "defined": "1.0.0",
+        "inherits": "2.0.3"
       }
     },
     "flush-write-stream": {
@@ -789,8 +789,8 @@
       "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.0.3.tgz",
       "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.4"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
       }
     },
     "foreach": {
@@ -808,9 +808,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "^0.4.0",
+        "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "^2.1.12"
+        "mime-types": "2.1.18"
       }
     },
     "framed-hash": {
@@ -823,8 +823,20 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
       "requires": {
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.0.0"
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6"
+      }
+    },
+    "fs-blob-store": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/fs-blob-store/-/fs-blob-store-5.2.1.tgz",
+      "integrity": "sha1-Kn2371ml7FSMzoVkBmUIIkybBFc=",
+      "dev": true,
+      "requires": {
+        "duplexify": "3.6.0",
+        "end-of-stream": "1.4.1",
+        "lru-cache": "2.7.3",
+        "mkdirp": "0.5.1"
       }
     },
     "fs-constants": {
@@ -837,11 +849,11 @@
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
       "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
       "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^2.1.0",
-        "klaw": "^1.0.0",
-        "path-is-absolute": "^1.0.0",
-        "rimraf": "^2.2.8"
+        "graceful-fs": "4.1.11",
+        "jsonfile": "2.4.0",
+        "klaw": "1.3.1",
+        "path-is-absolute": "1.0.1",
+        "rimraf": "2.6.2"
       }
     },
     "fs-walk": {
@@ -849,7 +861,7 @@
       "resolved": "https://registry.npmjs.org/fs-walk/-/fs-walk-0.0.2.tgz",
       "integrity": "sha1-IhA4W9vDKrUZM87lAu8YUWeXYE0=",
       "requires": {
-        "async": "*"
+        "async": "2.6.1"
       }
     },
     "fs.realpath": {
@@ -867,14 +879,14 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "requires": {
-        "aproba": "^1.0.3",
-        "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
-        "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
       }
     },
     "generate-function": {
@@ -887,7 +899,7 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
       "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
       "requires": {
-        "is-property": "^1.0.0"
+        "is-property": "1.0.2"
       }
     },
     "getpass": {
@@ -895,7 +907,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "^1.0.0"
+        "assert-plus": "1.0.0"
       }
     },
     "github-from-package": {
@@ -908,11 +920,11 @@
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
       "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
       "requires": {
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "2 || 3",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
       }
     },
     "graceful-fs": {
@@ -930,8 +942,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "^5.1.0",
-        "har-schema": "^2.0.0"
+        "ajv": "5.5.2",
+        "har-schema": "2.0.0"
       }
     },
     "has": {
@@ -939,7 +951,7 @@
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
-        "function-bind": "^1.1.1"
+        "function-bind": "1.1.1"
       }
     },
     "has-unicode": {
@@ -957,9 +969,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
+        "assert-plus": "1.0.0",
+        "jsprim": "1.4.1",
+        "sshpk": "1.14.2"
       }
     },
     "hyperkv": {
@@ -967,23 +979,23 @@
       "resolved": "https://registry.npmjs.org/hyperkv/-/hyperkv-2.0.5.tgz",
       "integrity": "sha1-THhT7so06ewMfvSNyZQDl7frz3U=",
       "requires": {
-        "defined": "^1.0.0",
-        "has": "^1.0.1",
-        "hyperlog": "^4.7.0",
-        "hyperlog-index": "^5.0.1",
-        "inherits": "^2.0.1",
-        "level": "^1.4.0",
-        "level-live-stream": "^1.4.12",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "mutexify": "^1.1.0",
-        "once": "^1.3.3",
-        "pump": "^1.0.2",
-        "read-only-stream": "^2.0.0",
-        "readable-stream": "^2.0.5",
-        "subleveldown": "^2.1.0",
-        "through2": "^2.0.0",
-        "xtend": "^4.0.1"
+        "defined": "1.0.0",
+        "has": "1.0.3",
+        "hyperlog": "4.12.1",
+        "hyperlog-index": "5.2.2",
+        "inherits": "2.0.3",
+        "level": "1.7.0",
+        "level-live-stream": "1.4.12",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "mutexify": "1.2.0",
+        "once": "1.4.0",
+        "pump": "1.0.3",
+        "read-only-stream": "2.0.0",
+        "readable-stream": "2.3.6",
+        "subleveldown": "2.1.0",
+        "through2": "2.0.3",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "pump": {
@@ -991,8 +1003,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -1002,26 +1014,26 @@
       "resolved": "https://registry.npmjs.org/hyperlog/-/hyperlog-4.12.1.tgz",
       "integrity": "sha1-bHzcJib3NEHy2Tudb0WDj9F9m10=",
       "requires": {
-        "after-all": "^2.0.2",
-        "bitfield": "^1.1.2",
-        "brfs": "^1.4.0",
-        "cuid": "^1.2.5",
-        "debug": "^2.2.0",
-        "defined": "^1.0.0",
-        "duplexify": "^3.4.2",
-        "framed-hash": "^1.1.0",
-        "from2": "^2.1.0",
-        "length-prefixed-stream": "^1.3.0",
-        "level-enumerate": "^1.0.1",
-        "level-logs": "^1.1.0",
-        "lexicographic-integer": "^1.1.0",
-        "mutexify": "^1.1.0",
-        "protocol-buffers": "^3.1.2",
-        "pump": "^1.0.0",
-        "run-parallel": "^1.1.6",
-        "run-waterfall": "^1.1.3",
-        "stream-collector": "^1.0.1",
-        "through2": "^2.0.0"
+        "after-all": "2.0.2",
+        "bitfield": "1.1.2",
+        "brfs": "1.6.1",
+        "cuid": "1.3.8",
+        "debug": "2.6.9",
+        "defined": "1.0.0",
+        "duplexify": "3.6.0",
+        "framed-hash": "1.1.0",
+        "from2": "2.3.0",
+        "length-prefixed-stream": "1.6.0",
+        "level-enumerate": "1.0.1",
+        "level-logs": "1.2.0",
+        "lexicographic-integer": "1.1.0",
+        "mutexify": "1.2.0",
+        "protocol-buffers": "3.2.1",
+        "pump": "1.0.3",
+        "run-parallel": "1.1.9",
+        "run-waterfall": "1.1.6",
+        "stream-collector": "1.0.1",
+        "through2": "2.0.3"
       },
       "dependencies": {
         "debug": {
@@ -1037,8 +1049,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -1048,8 +1060,8 @@
       "resolved": "https://registry.npmjs.org/hyperlog-index/-/hyperlog-index-5.2.2.tgz",
       "integrity": "sha1-XlxVaFbtFz5ewYtZXL3t/NnQHpk=",
       "requires": {
-        "inherits": "^2.0.1",
-        "through2": "^2.0.0"
+        "inherits": "2.0.3",
+        "through2": "2.0.3"
       }
     },
     "hyperlog-join": {
@@ -1057,12 +1069,12 @@
       "resolved": "https://registry.npmjs.org/hyperlog-join/-/hyperlog-join-2.0.1.tgz",
       "integrity": "sha1-hfI7DsvDfd8S7oG7xaoEAluvwpM=",
       "requires": {
-        "concat-stream": "^1.6.0",
-        "hyperlog-index": "^5.0.1",
-        "inherits": "^2.0.1",
-        "read-only-stream": "^2.0.0",
-        "subleveldown": "^2.1.0",
-        "through2": "^2.0.0"
+        "concat-stream": "1.6.2",
+        "hyperlog-index": "5.2.2",
+        "inherits": "2.0.3",
+        "read-only-stream": "2.0.0",
+        "subleveldown": "2.1.0",
+        "through2": "2.0.3"
       }
     },
     "hyperlog-kdb-index": {
@@ -1070,13 +1082,13 @@
       "resolved": "https://registry.npmjs.org/hyperlog-kdb-index/-/hyperlog-kdb-index-4.0.2.tgz",
       "integrity": "sha1-1dLtexY5Mg6SbzjWPehBiLaERcg=",
       "requires": {
-        "fd-chunk-store": "^2.0.0",
-        "hyperlog-index": "^5.0.1",
-        "inherits": "^2.0.1",
-        "once": "^1.3.3",
-        "read-only-stream": "^2.0.0",
-        "subleveldown": "^2.1.0",
-        "through2": "^2.0.0"
+        "fd-chunk-store": "2.0.0",
+        "hyperlog-index": "5.2.2",
+        "inherits": "2.0.3",
+        "once": "1.4.0",
+        "read-only-stream": "2.0.0",
+        "subleveldown": "2.1.0",
+        "through2": "2.0.3"
       }
     },
     "hyperlog-sneakernet-replicator": {
@@ -1084,14 +1096,14 @@
       "resolved": "https://registry.npmjs.org/hyperlog-sneakernet-replicator/-/hyperlog-sneakernet-replicator-1.1.5.tgz",
       "integrity": "sha1-Ch7rcUilV6XsxfG3ouovOc88PSs=",
       "requires": {
-        "debug": "^2.2.0",
-        "end-of-stream": "^1.1.0",
-        "graceful-fs": "^4.1.9",
-        "hyperlog": "^4.8.0",
-        "level": "^1.4.0",
-        "once": "^1.3.3",
-        "pump": "^1.0.1",
-        "tar-fs": "^1.13.2"
+        "debug": "2.6.9",
+        "end-of-stream": "1.4.1",
+        "graceful-fs": "4.1.11",
+        "hyperlog": "4.12.1",
+        "level": "1.7.0",
+        "once": "1.4.0",
+        "pump": "1.0.3",
+        "tar-fs": "1.16.3"
       },
       "dependencies": {
         "debug": {
@@ -1107,8 +1119,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -1118,7 +1130,7 @@
       "resolved": "https://registry.npmjs.org/idb-chunk-store/-/idb-chunk-store-0.1.3.tgz",
       "integrity": "sha1-Sn4UCo+GE/Lmwxz9fmMeckhrGqU=",
       "requires": {
-        "inherits": "^2.0.1"
+        "inherits": "2.0.3"
       }
     },
     "idb-wrapper": {
@@ -1141,8 +1153,8 @@
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
       }
     },
     "inherits": {
@@ -1175,7 +1187,7 @@
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
       "requires": {
-        "number-is-nan": "^1.0.0"
+        "number-is-nan": "1.0.1"
       }
     },
     "is-property": {
@@ -1188,7 +1200,7 @@
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
       "requires": {
-        "has": "^1.0.1"
+        "has": "1.0.3"
       }
     },
     "is-symbol": {
@@ -1242,7 +1254,7 @@
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
       "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
       "requires": {
-        "graceful-fs": "^4.1.6"
+        "graceful-fs": "4.1.11"
       }
     },
     "jsprim": {
@@ -1261,14 +1273,14 @@
       "resolved": "https://registry.npmjs.org/kdb-tree-store/-/kdb-tree-store-3.2.1.tgz",
       "integrity": "sha1-bF4YfUJhGZyMDIe/vUoWK5G9tvc=",
       "requires": {
-        "almost-equal": "^1.0.0",
-        "bounding-box-overlap-test": "^1.0.0",
-        "comparable-storable-types": "^1.0.0",
-        "inherits": "^2.0.1",
-        "median": "~0.0.2",
-        "once": "^1.3.3",
-        "readable-stream": "^2.0.4",
-        "xtend": "^4.0.1"
+        "almost-equal": "1.1.0",
+        "bounding-box-overlap-test": "1.0.0",
+        "comparable-storable-types": "1.0.0",
+        "inherits": "2.0.3",
+        "median": "0.0.2",
+        "once": "1.4.0",
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "klaw": {
@@ -1276,7 +1288,7 @@
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
       "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
       "requires": {
-        "graceful-fs": "^4.1.9"
+        "graceful-fs": "4.1.11"
       }
     },
     "length-prefixed-stream": {
@@ -1284,9 +1296,9 @@
       "resolved": "https://registry.npmjs.org/length-prefixed-stream/-/length-prefixed-stream-1.6.0.tgz",
       "integrity": "sha512-gsJvrb5giDqil/ScQ7fEoplsI2Ch4DwnvnfTW2EGl9KBW6Ekzn8JSNESObqNAeZD8HkSjEMvc5XjhuB66fsSZQ==",
       "requires": {
-        "buffer-alloc-unsafe": "^1.0.0",
-        "readable-stream": "^2.0.0",
-        "varint": "^5.0.0"
+        "buffer-alloc-unsafe": "1.1.0",
+        "readable-stream": "2.3.6",
+        "varint": "5.0.0"
       }
     },
     "level": {
@@ -1294,8 +1306,8 @@
       "resolved": "https://registry.npmjs.org/level/-/level-1.7.0.tgz",
       "integrity": "sha1-Q0ZKOounOy895WokKSgFFG2iE6E=",
       "requires": {
-        "level-packager": "~1.2.0",
-        "leveldown": "~1.7.0"
+        "level-packager": "1.2.1",
+        "leveldown": "1.7.2"
       }
     },
     "level-browserify": {
@@ -1303,9 +1315,9 @@
       "resolved": "https://registry.npmjs.org/level-browserify/-/level-browserify-1.1.2.tgz",
       "integrity": "sha512-rNP5sSaTwNxH9Y1XZTsgY7ZU6Z8KKMG5YD/4qLIyydtpUfNxrbJzYRF3R8prswpF/Lpnfx2OvL73n/Ng6NqZlw==",
       "requires": {
-        "level-js": "^2.1.6",
-        "level-packager": "~1.2.0",
-        "leveldown": "^3.0.0"
+        "level-js": "2.2.4",
+        "level-packager": "1.2.1",
+        "leveldown": "3.0.2"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -1313,7 +1325,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-4.0.3.tgz",
           "integrity": "sha512-qsIHFQy0u17JqSY+3ZUT+ykqxYY17yOfvAsLkFkw8kSQqi05d1jyj0bCuSX6sjYlXuY9cKpgUt5EudQdP4aXyA==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         },
         "leveldown": {
@@ -1321,11 +1333,11 @@
           "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-3.0.2.tgz",
           "integrity": "sha512-+ANRScj1npQQzv6e4DYAKRjVQZZ+ahMoubKrNP68nIq+l9bYgb+WiXF+14oTcQTg2f7qE9WHGW7rBG9nGSsA+A==",
           "requires": {
-            "abstract-leveldown": "~4.0.0",
-            "bindings": "~1.3.0",
-            "fast-future": "~1.0.2",
-            "nan": "~2.10.0",
-            "prebuild-install": "^4.0.0"
+            "abstract-leveldown": "4.0.3",
+            "bindings": "1.3.0",
+            "fast-future": "1.0.2",
+            "nan": "2.10.0",
+            "prebuild-install": "4.0.0"
           }
         }
       }
@@ -1340,7 +1352,7 @@
       "resolved": "https://registry.npmjs.org/level-enumerate/-/level-enumerate-1.0.1.tgz",
       "integrity": "sha1-2P2v8u92vW7U5J1yndXQ8SFoAb8=",
       "requires": {
-        "mutexify": "^1.0.1"
+        "mutexify": "1.2.0"
       }
     },
     "level-errors": {
@@ -1348,7 +1360,7 @@
       "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-1.0.5.tgz",
       "integrity": "sha512-/cLUpQduF6bNrWuAC4pwtUKA5t669pCsCi2XbmojG2tFeOr9j6ShtdDCtFFQO1DRt+EVZhx9gPzP9G2bUaG4ig==",
       "requires": {
-        "errno": "~0.1.1"
+        "errno": "0.1.7"
       }
     },
     "level-iterator-stream": {
@@ -1356,10 +1368,10 @@
       "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-1.3.1.tgz",
       "integrity": "sha1-5Dt4sagUPm+pek9IXrjqUwNS8u0=",
       "requires": {
-        "inherits": "^2.0.1",
-        "level-errors": "^1.0.3",
-        "readable-stream": "^1.0.33",
-        "xtend": "^4.0.0"
+        "inherits": "2.0.3",
+        "level-errors": "1.0.5",
+        "readable-stream": "1.1.14",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "isarray": {
@@ -1372,10 +1384,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -1390,12 +1402,12 @@
       "resolved": "https://registry.npmjs.org/level-js/-/level-js-2.2.4.tgz",
       "integrity": "sha1-vAVfQYBjXUSJtWHJSG+jcOjBFpc=",
       "requires": {
-        "abstract-leveldown": "~0.12.0",
-        "idb-wrapper": "^1.5.0",
-        "isbuffer": "~0.0.0",
-        "ltgt": "^2.1.2",
-        "typedarray-to-buffer": "~1.0.0",
-        "xtend": "~2.1.2"
+        "abstract-leveldown": "0.12.4",
+        "idb-wrapper": "1.7.2",
+        "isbuffer": "0.0.0",
+        "ltgt": "2.2.1",
+        "typedarray-to-buffer": "1.0.4",
+        "xtend": "2.1.2"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -1403,7 +1415,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
           "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
           "requires": {
-            "xtend": "~3.0.0"
+            "xtend": "3.0.0"
           },
           "dependencies": {
             "xtend": {
@@ -1423,7 +1435,7 @@
           "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
           "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
           "requires": {
-            "object-keys": "~0.4.0"
+            "object-keys": "0.4.0"
           }
         }
       }
@@ -1433,9 +1445,9 @@
       "resolved": "https://registry.npmjs.org/level-live-stream/-/level-live-stream-1.4.12.tgz",
       "integrity": "sha1-87jKj4n8Ec+y4P2rZJhOzs1aUhE=",
       "requires": {
-        "level-sublevel": "^6.6.1",
-        "pull-level": "^2.0.3",
-        "pull-stream-to-stream": "~1.2.4"
+        "level-sublevel": "6.6.2",
+        "pull-level": "2.0.4",
+        "pull-stream-to-stream": "1.2.6"
       }
     },
     "level-logs": {
@@ -1443,11 +1455,11 @@
       "resolved": "https://registry.npmjs.org/level-logs/-/level-logs-1.2.0.tgz",
       "integrity": "sha512-Lr9HDKs1KsPyUU40s37zGGbA7zogzIbvK/CM3c5SKXROyah7Ci1y8H2gPfRpr9z/kkQH6KVERlMrBi819xPm2A==",
       "requires": {
-        "from2": "^1.3.0",
-        "lexicographic-integer": "^1.1.0",
-        "pump": "^1.0.0",
-        "stream-collector": "^1.0.1",
-        "through2": "^0.6.3"
+        "from2": "1.3.0",
+        "lexicographic-integer": "1.1.0",
+        "pump": "1.0.3",
+        "stream-collector": "1.0.1",
+        "through2": "0.6.5"
       },
       "dependencies": {
         "from2": {
@@ -1455,8 +1467,8 @@
           "resolved": "https://registry.npmjs.org/from2/-/from2-1.3.0.tgz",
           "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
           "requires": {
-            "inherits": "~2.0.1",
-            "readable-stream": "~1.1.10"
+            "inherits": "2.0.3",
+            "readable-stream": "1.1.14"
           }
         },
         "isarray": {
@@ -1469,8 +1481,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         },
         "readable-stream": {
@@ -1478,10 +1490,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
           "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "string_decoder": {
@@ -1494,8 +1506,8 @@
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
           "requires": {
-            "readable-stream": ">=1.0.33-1 <1.1.0-0",
-            "xtend": ">=4.0.0 <4.1.0-0"
+            "readable-stream": "1.0.34",
+            "xtend": "4.0.1"
           },
           "dependencies": {
             "readable-stream": {
@@ -1503,10 +1515,10 @@
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
               "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
               "requires": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
                 "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
+                "string_decoder": "0.10.31"
               }
             }
           }
@@ -1518,7 +1530,7 @@
       "resolved": "https://registry.npmjs.org/level-option-wrap/-/level-option-wrap-1.1.0.tgz",
       "integrity": "sha1-rSDmjZ88IsiJdTHMaqevWWse0Sk=",
       "requires": {
-        "defined": "~0.0.0"
+        "defined": "0.0.0"
       },
       "dependencies": {
         "defined": {
@@ -1533,7 +1545,7 @@
       "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-1.2.1.tgz",
       "integrity": "sha1-Bn/t/Qcrf+PGvsYIDAy9SmsuEfQ=",
       "requires": {
-        "levelup": "~1.3.0"
+        "levelup": "1.3.9"
       }
     },
     "level-post": {
@@ -1541,7 +1553,7 @@
       "resolved": "https://registry.npmjs.org/level-post/-/level-post-1.0.7.tgz",
       "integrity": "sha512-PWYqG4Q00asOrLhX7BejSajByB4EmG2GaKHfj3h5UmmZ2duciXLPGYWIjBzLECFWUGOZWlm5B20h/n3Gs3HKew==",
       "requires": {
-        "ltgt": "^2.1.2"
+        "ltgt": "2.2.1"
       }
     },
     "level-sublevel": {
@@ -1549,14 +1561,14 @@
       "resolved": "https://registry.npmjs.org/level-sublevel/-/level-sublevel-6.6.2.tgz",
       "integrity": "sha512-+hptqmFYPKFju9QG4F6scvx3ZXkhrSmmhYui+hPzRn/jiC3DJ6VNZRKsIhGMpeajVBWfRV7XiysUThrJ/7PgXQ==",
       "requires": {
-        "bytewise": "~1.1.0",
-        "levelup": "~0.19.0",
-        "ltgt": "~2.1.1",
-        "pull-defer": "^0.2.2",
-        "pull-level": "^2.0.3",
-        "pull-stream": "^3.6.8",
-        "typewiselite": "~1.0.0",
-        "xtend": "~4.0.0"
+        "bytewise": "1.1.0",
+        "levelup": "0.19.1",
+        "ltgt": "2.1.3",
+        "pull-defer": "0.2.2",
+        "pull-level": "2.0.4",
+        "pull-stream": "3.6.8",
+        "typewiselite": "1.0.0",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -1564,7 +1576,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-0.12.4.tgz",
           "integrity": "sha1-KeGOYy5g5OIh1YECR4UqY9ey5BA=",
           "requires": {
-            "xtend": "~3.0.0"
+            "xtend": "3.0.0"
           },
           "dependencies": {
             "xtend": {
@@ -1579,7 +1591,7 @@
           "resolved": "https://registry.npmjs.org/bl/-/bl-0.8.2.tgz",
           "integrity": "sha1-yba8oI0bwuoA/Ir7Txpf0eHGbk4=",
           "requires": {
-            "readable-stream": "~1.0.26"
+            "readable-stream": "1.0.34"
           }
         },
         "deferred-leveldown": {
@@ -1587,7 +1599,7 @@
           "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-0.2.0.tgz",
           "integrity": "sha1-LO8fER4cV4cNi7uK8mUOWHzS9bQ=",
           "requires": {
-            "abstract-leveldown": "~0.12.1"
+            "abstract-leveldown": "0.12.4"
           }
         },
         "isarray": {
@@ -1600,13 +1612,13 @@
           "resolved": "https://registry.npmjs.org/levelup/-/levelup-0.19.1.tgz",
           "integrity": "sha1-86anIFJyxLXzXkEv8ASgOgrt9Qs=",
           "requires": {
-            "bl": "~0.8.1",
-            "deferred-leveldown": "~0.2.0",
-            "errno": "~0.1.1",
-            "prr": "~0.0.0",
-            "readable-stream": "~1.0.26",
-            "semver": "~5.1.0",
-            "xtend": "~3.0.0"
+            "bl": "0.8.2",
+            "deferred-leveldown": "0.2.0",
+            "errno": "0.1.7",
+            "prr": "0.0.0",
+            "readable-stream": "1.0.34",
+            "semver": "5.1.1",
+            "xtend": "3.0.0"
           },
           "dependencies": {
             "xtend": {
@@ -1631,10 +1643,10 @@
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
           "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
             "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
+            "string_decoder": "0.10.31"
           }
         },
         "semver": {
@@ -1654,11 +1666,11 @@
       "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-1.7.2.tgz",
       "integrity": "sha1-XjRnuyfuJGpKe429j7KxYgam64s=",
       "requires": {
-        "abstract-leveldown": "~2.6.1",
-        "bindings": "~1.2.1",
-        "fast-future": "~1.0.2",
-        "nan": "~2.6.1",
-        "prebuild-install": "^2.1.0"
+        "abstract-leveldown": "2.6.3",
+        "bindings": "1.2.1",
+        "fast-future": "1.0.2",
+        "nan": "2.6.2",
+        "prebuild-install": "2.5.3"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -1666,7 +1678,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.6.3.tgz",
           "integrity": "sha512-2++wDf/DYqkPR3o5tbfdhF96EfMApo1GpPfzOsR/ZYXdkSmELlvOOEAl9iKkRsktMPHdGjO4rtkBpf2I7TiTeA==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         },
         "bindings": {
@@ -1684,21 +1696,32 @@
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
           "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
           "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.1",
             "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.4.3",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.8",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.3",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            }
           }
         }
       }
@@ -1708,11 +1731,11 @@
       "resolved": "https://registry.npmjs.org/leveldown-android-prebuilt/-/leveldown-android-prebuilt-2.0.3.tgz",
       "integrity": "sha512-8pBhPY0aE9pbPsxuuWhMJj9L2/kSaZjoobC18okYexpUbhYTJJOPGgTj8UkluXODWSJOsc3GcgWh+QduZtBWwA==",
       "requires": {
-        "abstract-leveldown": "~3.0.0",
-        "bindings": "~1.3.0",
-        "fast-future": "~1.0.2",
-        "nan": "~2.8.0",
-        "prebuild-install": "^2.1.0"
+        "abstract-leveldown": "3.0.0",
+        "bindings": "1.3.0",
+        "fast-future": "1.0.2",
+        "nan": "2.8.0",
+        "prebuild-install": "2.5.3"
       },
       "dependencies": {
         "nan": {
@@ -1725,21 +1748,32 @@
           "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
           "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
           "requires": {
-            "detect-libc": "^1.0.3",
-            "expand-template": "^1.0.2",
+            "detect-libc": "1.0.3",
+            "expand-template": "1.1.1",
             "github-from-package": "0.0.0",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "node-abi": "^2.2.0",
-            "noop-logger": "^0.1.1",
-            "npmlog": "^4.0.1",
-            "os-homedir": "^1.0.1",
-            "pump": "^2.0.1",
-            "rc": "^1.1.6",
-            "simple-get": "^2.7.0",
-            "tar-fs": "^1.13.0",
-            "tunnel-agent": "^0.6.0",
-            "which-pm-runs": "^1.0.0"
+            "minimist": "1.2.0",
+            "mkdirp": "0.5.1",
+            "node-abi": "2.4.3",
+            "noop-logger": "0.1.1",
+            "npmlog": "4.1.2",
+            "os-homedir": "1.0.2",
+            "pump": "2.0.1",
+            "rc": "1.2.8",
+            "simple-get": "2.8.1",
+            "tar-fs": "1.16.3",
+            "tunnel-agent": "0.6.0",
+            "which-pm-runs": "1.0.0"
+          },
+          "dependencies": {
+            "pump": {
+              "version": "2.0.1",
+              "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+              "requires": {
+                "end-of-stream": "1.4.1",
+                "once": "1.4.0"
+              }
+            }
           }
         }
       }
@@ -1749,13 +1783,13 @@
       "resolved": "https://registry.npmjs.org/levelup/-/levelup-1.3.9.tgz",
       "integrity": "sha512-VVGHfKIlmw8w1XqpGOAGwq6sZm2WwWLmlDcULkKWQXEA5EopA8OBNJ2Ck2v6bdk8HeEZSbCSEgzXadyQFm76sQ==",
       "requires": {
-        "deferred-leveldown": "~1.2.1",
-        "level-codec": "~7.0.0",
-        "level-errors": "~1.0.3",
-        "level-iterator-stream": "~1.3.0",
-        "prr": "~1.0.1",
-        "semver": "~5.4.1",
-        "xtend": "~4.0.0"
+        "deferred-leveldown": "1.2.2",
+        "level-codec": "7.0.1",
+        "level-errors": "1.0.5",
+        "level-iterator-stream": "1.3.1",
+        "prr": "1.0.1",
+        "semver": "5.4.1",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "semver": {
@@ -1770,8 +1804,8 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
       }
     },
     "lexicographic-integer": {
@@ -1804,7 +1838,7 @@
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
       "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
       "requires": {
-        "vlq": "^0.2.2"
+        "vlq": "0.2.3"
       }
     },
     "mapeo-server": {
@@ -1812,13 +1846,13 @@
       "resolved": "https://registry.npmjs.org/mapeo-server/-/mapeo-server-7.0.0.tgz",
       "integrity": "sha1-RSbqpvrWu3XlS8u0jZlINMMmUAo=",
       "requires": {
-        "asar": "^0.14.3",
-        "body": "^5.1.0",
-        "ecstatic": "^3.2.0",
-        "mapeo-sync": "^2.0.0",
-        "randombytes": "^2.0.6",
-        "routes": "^2.1.0",
-        "xtend": "^4.0.1"
+        "asar": "0.14.3",
+        "body": "5.1.0",
+        "ecstatic": "3.2.1",
+        "mapeo-sync": "2.0.2",
+        "randombytes": "2.0.6",
+        "routes": "2.1.0",
+        "xtend": "4.0.1"
       }
     },
     "mapeo-styles": {
@@ -1826,8 +1860,8 @@
       "resolved": "https://registry.npmjs.org/mapeo-styles/-/mapeo-styles-2.0.0.tgz",
       "integrity": "sha512-1wGvnGScJwDfs6msI/HKNkGXtcRZsEzvtFqxbUJBRxiwJeFW0Lx3FAb+7PWSN7gyGWvKp6WNayq6n5bqd3989g==",
       "requires": {
-        "mkdirp": "^0.5.1",
-        "ncp": "^2.0.0"
+        "mkdirp": "0.5.1",
+        "ncp": "2.0.0"
       }
     },
     "mapeo-sync": {
@@ -1835,16 +1869,16 @@
       "resolved": "https://registry.npmjs.org/mapeo-sync/-/mapeo-sync-2.0.2.tgz",
       "integrity": "sha1-OScuaxeI/G20hQJcZ6qrl3eZYtU=",
       "requires": {
-        "blob-store-replication-stream": "^1.1.0",
-        "bonjour": "^3.5.0",
-        "debug": "^3.1.0",
-        "end-of-stream": "^1.4.1",
-        "hyperlog-sneakernet-replicator": "^1.1.5",
-        "inherits": "^2.0.3",
-        "object.values": "^1.0.4",
-        "pump": "^3.0.0",
-        "randombytes": "^2.0.6",
-        "websocket-stream": "^5.1.2"
+        "blob-store-replication-stream": "1.1.1",
+        "bonjour": "3.5.0",
+        "debug": "3.1.0",
+        "end-of-stream": "1.4.1",
+        "hyperlog-sneakernet-replicator": "1.1.5",
+        "inherits": "2.0.3",
+        "object.values": "1.0.4",
+        "pump": "3.0.0",
+        "randombytes": "2.0.6",
+        "websocket-stream": "5.1.2"
       },
       "dependencies": {
         "pump": {
@@ -1852,8 +1886,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
           "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -1868,7 +1902,7 @@
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
       "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
       "requires": {
-        "source-map": "^0.5.6"
+        "source-map": "0.5.7"
       },
       "dependencies": {
         "source-map": {
@@ -1893,7 +1927,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "~1.33.0"
+        "mime-db": "1.33.0"
       }
     },
     "mimic-response": {
@@ -1906,7 +1940,7 @@
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "1.1.11"
       }
     },
     "minimist": {
@@ -1941,7 +1975,7 @@
       "requires": {
         "decompress-zip": "0.3.0",
         "fs-extra": "0.26.7",
-        "request": "^2.79.0"
+        "request": "2.87.0"
       }
     },
     "ms": {
@@ -1954,8 +1988,8 @@
       "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-6.2.3.tgz",
       "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
       "requires": {
-        "dns-packet": "^1.3.1",
-        "thunky": "^1.0.2"
+        "dns-packet": "1.3.1",
+        "thunky": "1.0.2"
       }
     },
     "multicast-dns-service-types": {
@@ -1983,7 +2017,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
       "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
       "requires": {
-        "semver": "^5.4.1"
+        "semver": "5.5.0"
       }
     },
     "node-fingerprint": {
@@ -2001,7 +2035,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
       "requires": {
-        "abbrev": "1"
+        "abbrev": "1.1.1"
       }
     },
     "npmlog": {
@@ -2009,10 +2043,10 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "requires": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
       }
     },
     "number-is-nan": {
@@ -2045,10 +2079,10 @@
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
       "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.6.1",
-        "function-bind": "^1.1.0",
-        "has": "^1.0.1"
+        "define-properties": "1.1.2",
+        "es-abstract": "1.12.0",
+        "function-bind": "1.1.1",
+        "has": "1.0.3"
       }
     },
     "once": {
@@ -2056,7 +2090,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "requires": {
-        "wrappy": "1"
+        "wrappy": "1.0.2"
       }
     },
     "optionator": {
@@ -2064,12 +2098,12 @@
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
       }
     },
     "os-homedir": {
@@ -2087,17 +2121,17 @@
       "resolved": "https://registry.npmjs.org/osm-p2p/-/osm-p2p-2.0.0.tgz",
       "integrity": "sha1-sjvey0FqIn5i1hhvAkkuH2O/3Eo=",
       "requires": {
-        "deferred-chunk-store": "^1.0.1",
-        "deferred-leveldown": "^1.2.1",
-        "fd-chunk-store": "^2.0.0",
-        "hyperlog": "^4.10.0",
-        "idb-chunk-store": "~0.1.0",
-        "level-browserify": "^1.1.0",
-        "leveldown": "^1.4.4",
-        "levelup": "^1.3.1",
-        "mkdirp": "^0.5.1",
-        "once": "^1.3.3",
-        "osm-p2p-db": "^4.0.0"
+        "deferred-chunk-store": "1.0.1",
+        "deferred-leveldown": "1.2.2",
+        "fd-chunk-store": "2.0.0",
+        "hyperlog": "4.12.1",
+        "idb-chunk-store": "0.1.3",
+        "level-browserify": "1.1.2",
+        "leveldown": "1.7.2",
+        "levelup": "1.3.9",
+        "mkdirp": "0.5.1",
+        "once": "1.4.0",
+        "osm-p2p-db": "4.4.0"
       }
     },
     "osm-p2p-db": {
@@ -2105,23 +2139,23 @@
       "resolved": "https://registry.npmjs.org/osm-p2p-db/-/osm-p2p-db-4.4.0.tgz",
       "integrity": "sha1-UK8SWCmhE7Zx5nakug99azYRTMg=",
       "requires": {
-        "after-all": "^2.0.2",
-        "async": "^2.3.0",
-        "base-convertor": "^1.1.0",
-        "defined": "^1.0.0",
-        "hyperkv": "^2.0.1",
-        "hyperlog-join": "^2.0.0",
-        "hyperlog-kdb-index": "^4.0.0",
-        "inherits": "^2.0.1",
-        "kdb-tree-store": "^3.0.2",
-        "mutexify": "^1.1.0",
-        "once": "^1.3.3",
+        "after-all": "2.0.2",
+        "async": "2.6.1",
+        "base-convertor": "1.1.0",
+        "defined": "1.0.0",
+        "hyperkv": "2.0.5",
+        "hyperlog-join": "2.0.1",
+        "hyperlog-kdb-index": "4.0.2",
+        "inherits": "2.0.3",
+        "kdb-tree-store": "3.2.1",
+        "mutexify": "1.2.0",
+        "once": "1.4.0",
         "randombytes": "2.0.1",
-        "read-only-stream": "^2.0.0",
-        "subleveldown": "^2.1.0",
-        "through2": "^2.0.0",
-        "to2": "^1.0.0",
-        "xtend": "^4.0.1"
+        "read-only-stream": "2.0.0",
+        "subleveldown": "2.1.0",
+        "through2": "2.0.3",
+        "to2": "1.0.0",
+        "xtend": "4.0.1"
       },
       "dependencies": {
         "randombytes": {
@@ -2151,21 +2185,32 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
       "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
       "requires": {
-        "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "detect-libc": "1.0.3",
+        "expand-template": "1.1.1",
         "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
-        "noop-logger": "^0.1.1",
-        "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
-        "rc": "^1.1.6",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
-        "tunnel-agent": "^0.6.0",
-        "which-pm-runs": "^1.0.0"
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "node-abi": "2.4.3",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "2.0.1",
+        "rc": "1.2.8",
+        "simple-get": "2.8.1",
+        "tar-fs": "1.16.3",
+        "tunnel-agent": "0.6.0",
+        "which-pm-runs": "1.0.0"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+          "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        }
       }
     },
     "prelude-ls": {
@@ -2183,12 +2228,12 @@
       "resolved": "https://registry.npmjs.org/protocol-buffers/-/protocol-buffers-3.2.1.tgz",
       "integrity": "sha1-NyWOF+JKCC8G67F3MekoUdHHaIk=",
       "requires": {
-        "brfs": "^1.4.0",
-        "generate-function": "^2.0.0",
-        "generate-object-property": "^1.2.0",
-        "protocol-buffers-schema": "^3.1.1",
-        "signed-varint": "^2.0.0",
-        "varint": "^5.0.0"
+        "brfs": "1.6.1",
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "protocol-buffers-schema": "3.3.2",
+        "signed-varint": "2.0.1",
+        "varint": "5.0.0"
       }
     },
     "protocol-buffers-schema": {
@@ -2221,13 +2266,13 @@
       "resolved": "https://registry.npmjs.org/pull-level/-/pull-level-2.0.4.tgz",
       "integrity": "sha512-fW6pljDeUThpq5KXwKbRG3X7Ogk3vc75d5OQU/TvXXui65ykm+Bn+fiktg+MOx2jJ85cd+sheufPL+rw9QSVZg==",
       "requires": {
-        "level-post": "^1.0.7",
-        "pull-cat": "^1.1.9",
-        "pull-live": "^1.0.1",
-        "pull-pushable": "^2.0.0",
-        "pull-stream": "^3.4.0",
-        "pull-window": "^2.1.4",
-        "stream-to-pull-stream": "^1.7.1"
+        "level-post": "1.0.7",
+        "pull-cat": "1.1.11",
+        "pull-live": "1.0.1",
+        "pull-pushable": "2.2.0",
+        "pull-stream": "3.6.8",
+        "pull-window": "2.1.4",
+        "stream-to-pull-stream": "1.7.2"
       }
     },
     "pull-live": {
@@ -2235,8 +2280,8 @@
       "resolved": "https://registry.npmjs.org/pull-live/-/pull-live-1.0.1.tgz",
       "integrity": "sha1-pOzuAeMwFV6RJLu89HYfIbOPUfU=",
       "requires": {
-        "pull-cat": "^1.1.9",
-        "pull-stream": "^3.4.0"
+        "pull-cat": "1.1.11",
+        "pull-stream": "3.6.8"
       }
     },
     "pull-pushable": {
@@ -2254,7 +2299,7 @@
       "resolved": "https://registry.npmjs.org/pull-stream-to-stream/-/pull-stream-to-stream-1.2.6.tgz",
       "integrity": "sha1-3Z+jcy7bPRbmfNHyJLyjim1XSMc=",
       "requires": {
-        "pull-core": "1"
+        "pull-core": "1.1.0"
       }
     },
     "pull-window": {
@@ -2262,16 +2307,16 @@
       "resolved": "https://registry.npmjs.org/pull-window/-/pull-window-2.1.4.tgz",
       "integrity": "sha1-/DuG/uvRkgx64pdpHiP3BfiFUvA=",
       "requires": {
-        "looper": "^2.0.0"
+        "looper": "2.0.0"
       }
     },
     "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
       }
     },
     "punycode": {
@@ -2295,8 +2340,8 @@
       "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
       "requires": {
         "buffer-equal": "0.0.1",
-        "minimist": "^1.1.3",
-        "through2": "^2.0.0"
+        "minimist": "1.2.0",
+        "through2": "2.0.3"
       }
     },
     "randombytes": {
@@ -2304,7 +2349,7 @@
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
       "requires": {
-        "safe-buffer": "^5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "raw-body": {
@@ -2312,8 +2357,8 @@
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
       "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
       "requires": {
-        "bytes": "1",
-        "string_decoder": "0.10"
+        "bytes": "1.0.0",
+        "string_decoder": "0.10.31"
       },
       "dependencies": {
         "string_decoder": {
@@ -2328,10 +2373,10 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "requires": {
-        "deep-extend": "^0.6.0",
-        "ini": "~1.3.0",
-        "minimist": "^1.2.0",
-        "strip-json-comments": "~2.0.1"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       }
     },
     "read-only-stream": {
@@ -2339,7 +2384,7 @@
       "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
       "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
       "requires": {
-        "readable-stream": "^2.0.2"
+        "readable-stream": "2.3.6"
       }
     },
     "readable-stream": {
@@ -2347,13 +2392,13 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
       "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "2.0.0",
+        "safe-buffer": "5.1.2",
+        "string_decoder": "1.1.1",
+        "util-deprecate": "1.0.2"
       }
     },
     "request": {
@@ -2361,26 +2406,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.6.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.5",
-        "extend": "~3.0.1",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.1",
-        "har-validator": "~5.0.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.17",
-        "oauth-sign": "~0.8.2",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.1",
-        "safe-buffer": "^5.1.1",
-        "tough-cookie": "~2.3.3",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.1.0"
+        "aws-sign2": "0.7.0",
+        "aws4": "1.7.0",
+        "caseless": "0.12.0",
+        "combined-stream": "1.0.6",
+        "extend": "3.0.1",
+        "forever-agent": "0.6.1",
+        "form-data": "2.3.2",
+        "har-validator": "5.0.3",
+        "http-signature": "1.2.0",
+        "is-typedarray": "1.0.0",
+        "isstream": "0.1.2",
+        "json-stringify-safe": "5.0.1",
+        "mime-types": "2.1.18",
+        "oauth-sign": "0.8.2",
+        "performance-now": "2.1.0",
+        "qs": "6.5.2",
+        "safe-buffer": "5.1.2",
+        "tough-cookie": "2.3.4",
+        "tunnel-agent": "0.6.0",
+        "uuid": "3.3.2"
       }
     },
     "resolve": {
@@ -2388,7 +2433,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
       "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "requires": {
-        "path-parse": "^1.0.5"
+        "path-parse": "1.0.5"
       }
     },
     "rimraf": {
@@ -2396,7 +2441,7 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "7.1.2"
       },
       "dependencies": {
         "glob": {
@@ -2404,12 +2449,12 @@
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
         }
       }
@@ -2439,9 +2484,9 @@
       "resolved": "https://registry.npmjs.org/safe-fs-blob-store/-/safe-fs-blob-store-1.0.1.tgz",
       "integrity": "sha512-29fgUDC9v4TG4vP005fMi/cqIMZa6+LZQDNPkHfe8cqo+wTLH37rR7L4OFakOz50B4YYbUUOFxB6fOJTaOOBKg==",
       "requires": {
-        "@digidem/atomic-fs-blob-store": "^5.3.0",
+        "@digidem/atomic-fs-blob-store": "5.3.0",
         "fs-walk": "0.0.1",
-        "imurmurhash": "^0.1.4"
+        "imurmurhash": "0.1.4"
       },
       "dependencies": {
         "fs-walk": {
@@ -2449,7 +2494,7 @@
           "resolved": "https://registry.npmjs.org/fs-walk/-/fs-walk-0.0.1.tgz",
           "integrity": "sha1-9/yRw64e6tB8mYvF0N1B8tvr0zU=",
           "requires": {
-            "async": "*"
+            "async": "2.6.1"
           }
         }
       }
@@ -2489,7 +2534,7 @@
       "resolved": "https://registry.npmjs.org/signed-varint/-/signed-varint-2.0.1.tgz",
       "integrity": "sha1-UKmYnafJjCxh2tEZvJdHDvhSgSk=",
       "requires": {
-        "varint": "~5.0.0"
+        "varint": "5.0.0"
       }
     },
     "simple-concat": {
@@ -2502,9 +2547,9 @@
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
       "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
       "requires": {
-        "decompress-response": "^3.3.0",
-        "once": "^1.3.1",
-        "simple-concat": "^1.0.0"
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
       }
     },
     "source-map": {
@@ -2518,15 +2563,15 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
+        "asn1": "0.2.3",
+        "assert-plus": "1.0.0",
+        "bcrypt-pbkdf": "1.0.2",
+        "dashdash": "1.14.1",
+        "ecc-jsbn": "0.1.1",
+        "getpass": "0.1.7",
+        "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
+        "tweetnacl": "0.14.5"
       }
     },
     "static-eval": {
@@ -2534,7 +2579,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
       "integrity": "sha512-6flshd3F1Gwm+Ksxq463LtFd1liC77N/PX1FVVc3OzL3hAmo2fwHFbuArkcfi7s9rTNsLEhcRmXGFZhlgy40uw==",
       "requires": {
-        "escodegen": "^1.8.1"
+        "escodegen": "1.9.1"
       }
     },
     "static-module": {
@@ -2542,20 +2587,20 @@
       "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
       "integrity": "sha512-D8vv82E/Kpmz3TXHKG8PPsCPg+RAX6cbCOyvjM6x04qZtQ47EtJFVwRsdov3n5d6/6ynrOY9XB4JkaZwB2xoRQ==",
       "requires": {
-        "concat-stream": "~1.6.0",
-        "convert-source-map": "^1.5.1",
-        "duplexer2": "~0.1.4",
-        "escodegen": "~1.9.0",
-        "falafel": "^2.1.0",
-        "has": "^1.0.1",
-        "magic-string": "^0.22.4",
+        "concat-stream": "1.6.2",
+        "convert-source-map": "1.5.1",
+        "duplexer2": "0.1.4",
+        "escodegen": "1.9.1",
+        "falafel": "2.1.0",
+        "has": "1.0.3",
+        "magic-string": "0.22.5",
         "merge-source-map": "1.0.4",
-        "object-inspect": "~1.4.0",
-        "quote-stream": "~1.0.2",
-        "readable-stream": "~2.3.3",
-        "shallow-copy": "~0.0.1",
-        "static-eval": "^2.0.0",
-        "through2": "~2.0.3"
+        "object-inspect": "1.4.1",
+        "quote-stream": "1.0.2",
+        "readable-stream": "2.3.6",
+        "shallow-copy": "0.0.1",
+        "static-eval": "2.0.0",
+        "through2": "2.0.3"
       }
     },
     "stream-collector": {
@@ -2563,7 +2608,7 @@
       "resolved": "https://registry.npmjs.org/stream-collector/-/stream-collector-1.0.1.tgz",
       "integrity": "sha1-TU5V8XE1YSGyxfZVn5RHBaso2xU=",
       "requires": {
-        "once": "^1.3.1"
+        "once": "1.4.0"
       }
     },
     "stream-shift": {
@@ -2576,8 +2621,8 @@
       "resolved": "https://registry.npmjs.org/stream-to-pull-stream/-/stream-to-pull-stream-1.7.2.tgz",
       "integrity": "sha1-dXYJrhzr0zx0MtSvvjH/eGULnd4=",
       "requires": {
-        "looper": "^3.0.0",
-        "pull-stream": "^3.2.3"
+        "looper": "3.0.0",
+        "pull-stream": "3.6.8"
       },
       "dependencies": {
         "looper": {
@@ -2597,9 +2642,9 @@
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
       "requires": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
       }
     },
     "string_decoder": {
@@ -2607,7 +2652,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "5.1.2"
       }
     },
     "strip-ansi": {
@@ -2615,7 +2660,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
-        "ansi-regex": "^2.0.0"
+        "ansi-regex": "2.1.1"
       }
     },
     "strip-json-comments": {
@@ -2628,9 +2673,9 @@
       "resolved": "https://registry.npmjs.org/subleveldown/-/subleveldown-2.1.0.tgz",
       "integrity": "sha1-sj7KI8IodypnxsTkSWlDBPDXBqE=",
       "requires": {
-        "abstract-leveldown": "^2.4.1",
-        "level-option-wrap": "^1.1.0",
-        "levelup": "^1.2.1"
+        "abstract-leveldown": "2.7.2",
+        "level-option-wrap": "1.1.0",
+        "levelup": "1.3.9"
       },
       "dependencies": {
         "abstract-leveldown": {
@@ -2638,7 +2683,7 @@
           "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-2.7.2.tgz",
           "integrity": "sha512-+OVvxH2rHVEhWLdbudP6p0+dNMXu8JA1CbhP19T8paTYAcX7oJ4OVjT+ZUVpv7mITxXHqDMej+GdqXBmXkw09w==",
           "requires": {
-            "xtend": "~4.0.0"
+            "xtend": "4.0.1"
           }
         }
       }
@@ -2648,10 +2693,10 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
       "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
       "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
+        "chownr": "1.0.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.6.1"
       },
       "dependencies": {
         "pump": {
@@ -2659,8 +2704,8 @@
           "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
           "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
           "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
           }
         }
       }
@@ -2670,13 +2715,13 @@
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
       "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.1.0",
-        "end-of-stream": "^1.0.0",
-        "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.0",
-        "xtend": "^4.0.0"
+        "bl": "1.2.2",
+        "buffer-alloc": "1.2.0",
+        "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "through2": {
@@ -2684,8 +2729,8 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
       "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
       "requires": {
-        "readable-stream": "^2.1.5",
-        "xtend": "~4.0.1"
+        "readable-stream": "2.3.6",
+        "xtend": "4.0.1"
       }
     },
     "thunky": {
@@ -2698,7 +2743,7 @@
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
       "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
       "requires": {
-        "os-tmpdir": "~1.0.1"
+        "os-tmpdir": "1.0.2"
       }
     },
     "to-buffer": {
@@ -2711,7 +2756,7 @@
       "resolved": "https://registry.npmjs.org/to2/-/to2-1.0.0.tgz",
       "integrity": "sha1-EfDgsWGANVf7Hk9tN1T5m5bg80A=",
       "requires": {
-        "flush-write-stream": "^1.0.0"
+        "flush-write-stream": "1.0.3"
       }
     },
     "touch": {
@@ -2719,7 +2764,7 @@
       "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
       "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
       "requires": {
-        "nopt": "~1.0.10"
+        "nopt": "1.0.10"
       },
       "dependencies": {
         "nopt": {
@@ -2727,7 +2772,7 @@
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
           "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
           "requires": {
-            "abbrev": "1"
+            "abbrev": "1.1.1"
           }
         }
       }
@@ -2737,7 +2782,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "^1.4.1"
+        "punycode": "1.4.1"
       }
     },
     "traverse": {
@@ -2750,7 +2795,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "^5.0.1"
+        "safe-buffer": "5.1.2"
       }
     },
     "tweetnacl": {
@@ -2764,7 +2809,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "requires": {
-        "prelude-ls": "~1.1.2"
+        "prelude-ls": "1.1.2"
       }
     },
     "typedarray": {
@@ -2782,7 +2827,7 @@
       "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
       "integrity": "sha1-EGeTZUCvl5N8xdz5kiSG6fooRlE=",
       "requires": {
-        "typewise-core": "^1.2.0"
+        "typewise-core": "1.2.0"
       }
     },
     "typewise-core": {
@@ -2810,9 +2855,9 @@
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-4.0.2.tgz",
       "integrity": "sha512-CS63Ssp6zynBQ4IxVzgjP5Abdo6LuJ87HFIcgIiVUeY96+MTHkqKtrUhphbwQ6jX8aSGZv8zX6l1DCPpfcAnxA==",
       "requires": {
-        "bindings": "~1.3.0",
-        "nan": "~2.10.0",
-        "prebuild-install": "~4.0.0"
+        "bindings": "1.3.0",
+        "nan": "2.10.0",
+        "prebuild-install": "4.0.0"
       }
     },
     "util-deprecate": {
@@ -2835,9 +2880,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "^1.0.0",
+        "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
+        "extsprintf": "1.3.0"
       }
     },
     "vlq": {
@@ -2850,12 +2895,12 @@
       "resolved": "https://registry.npmjs.org/websocket-stream/-/websocket-stream-5.1.2.tgz",
       "integrity": "sha512-lchLOk435iDWs0jNuL+hiU14i3ERSrMA0IKSiJh7z6X/i4XNsutBZrtqu2CPOZuA4G/zabiqVAos0vW+S7GEVw==",
       "requires": {
-        "duplexify": "^3.5.1",
-        "inherits": "^2.0.1",
-        "readable-stream": "^2.3.3",
-        "safe-buffer": "^5.1.1",
-        "ws": "^3.2.0",
-        "xtend": "^4.0.0"
+        "duplexify": "3.6.0",
+        "inherits": "2.0.3",
+        "readable-stream": "2.3.6",
+        "safe-buffer": "5.1.2",
+        "ws": "3.3.3",
+        "xtend": "4.0.1"
       }
     },
     "which-pm-runs": {
@@ -2868,7 +2913,7 @@
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "requires": {
-        "string-width": "^1.0.2 || 2"
+        "string-width": "1.0.2"
       }
     },
     "wordwrap": {
@@ -2886,9 +2931,9 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
       "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
-        "async-limiter": "~1.0.0",
-        "safe-buffer": "~5.1.0",
-        "ultron": "~1.1.0"
+        "async-limiter": "1.0.0",
+        "safe-buffer": "5.1.2",
+        "ultron": "1.1.1"
       }
     },
     "xtend": {

--- a/src/rnnodeapp/package-lock.json
+++ b/src/rnnodeapp/package-lock.json
@@ -2460,6 +2460,12 @@
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
       "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
     },
+    "run-series": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/run-series/-/run-series-1.1.8.tgz",
+      "integrity": "sha512-+GztYEPRpIsQoCSraWHDBs9WVy4eVME16zhOtDB4H9J4xN0XRhknnmLOl+4gRgZtu8dpp9N/utSPjKH/xmDzXg==",
+      "dev": true
+    },
     "run-waterfall": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.6.tgz",

--- a/src/rnnodeapp/package.json
+++ b/src/rnnodeapp/package.json
@@ -15,6 +15,7 @@
     "utf-8-validate": "^4.0.2"
   },
   "devDependencies": {
-    "fs-blob-store": "^5.2.1"
+    "fs-blob-store": "^5.2.1",
+    "run-series": "^1.1.8"
   }
 }

--- a/src/rnnodeapp/package.json
+++ b/src/rnnodeapp/package.json
@@ -10,7 +10,6 @@
     "mapeo-styles": "^2.0.0",
     "mkdirp": "0.5.1",
     "osm-p2p": "^2.0.0",
-    "pump": "^3.0.0",
     "run-parallel": "^1.1.9",
     "safe-fs-blob-store": "^1.0.1",
     "utf-8-validate": "^4.0.2"

--- a/src/rnnodeapp/package.json
+++ b/src/rnnodeapp/package.json
@@ -10,7 +10,12 @@
     "mapeo-styles": "^2.0.0",
     "mkdirp": "0.5.1",
     "osm-p2p": "^2.0.0",
+    "pump": "^3.0.0",
+    "run-parallel": "^1.1.9",
     "safe-fs-blob-store": "^1.0.1",
     "utf-8-validate": "^4.0.2"
+  },
+  "devDependencies": {
+    "fs-blob-store": "^5.2.1"
   }
 }

--- a/src/rnnodeapp/tests/migrationTest.js
+++ b/src/rnnodeapp/tests/migrationTest.js
@@ -1,0 +1,62 @@
+const concat = require('concat-stream')
+const mkdirp = require('mkdirp')
+const rimraf = require('rimraf')
+const pump = require('pump')
+const blobstore = require('fs-blob-store')
+const fs = require('fs')
+const safeBlobstore = require('safe-fs-blob-store')
+const path = require('path')
+const test = require('tape')
+const migrateMedia = require('../migrateMedia')
+const os = require('os')
+
+var key = 'mapeo-icon.png'
+const TEST_IMAGES = path.join(__dirname, '..', '..', 'images')
+const MEDIA_PATH = path.join(os.tmpdir(), 'media-test')
+
+test('migrates files', function (t) {
+  resetMediaPath()
+  var original = blobstore(MEDIA_PATH)
+  var testImage = path.join(TEST_IMAGES, key)
+
+  function done (err) {
+    t.error(err)
+    fs.access(path.join(MEDIA_PATH, key), function (err) {
+      t.ok(err, 'test image no longer exists in old blob store format')
+      t.end()
+    })
+  }
+
+  function doMigrate (err) {
+    t.error(err)
+    fs.access(path.join(MEDIA_PATH, key), function (err) {
+      t.error(err, 'test image exists in media path')
+
+      migrateMedia(MEDIA_PATH, function (err) {
+        t.error(err, 'error on migrate')
+        var safe = safeBlobstore(MEDIA_PATH)
+        var newFile = safe.createReadStream({key})
+        pump(newFile, concat(function (data) {
+          t.same(fs.readFileSync(testImage), data)
+        }), done)
+      })
+    })
+  }
+
+  var readStream = fs.createReadStream(testImage)
+  var writeStream = original.createWriteStream({key}, doMigrate)
+  readStream.pipe(writeStream)
+})
+
+test('when there is nothing to migrate, nothing happens', function (t) {
+  resetMediaPath()
+  migrateMedia(MEDIA_PATH, function (err) {
+    t.error(err, 'error on migrate')
+    t.end()
+  })
+})
+
+function resetMediaPath () {
+  rimraf.sync(MEDIA_PATH)
+  mkdirp.sync(MEDIA_PATH)
+}

--- a/src/rnnodeapp/tests/migrationTest.js
+++ b/src/rnnodeapp/tests/migrationTest.js
@@ -3,62 +3,92 @@ const mkdirp = require('mkdirp')
 const rimraf = require('rimraf')
 const blobstore = require('fs-blob-store')
 const fs = require('fs')
+const series = require('run-series')
 const safeBlobstore = require('safe-fs-blob-store')
 const path = require('path')
 const test = require('tape')
 const migrateMedia = require('../migrateMedia')
 const os = require('os')
 
-var key = 'mapeo-icon.png'
 const TEST_IMAGES = path.join(__dirname, '..', '..', 'images')
 const MEDIA_PATH = path.join(os.tmpdir(), 'media-test')
+const ORIGINAL_PATH = path.join(MEDIA_PATH, 'original')
+const THUMBNAIL_PATH = path.join(MEDIA_PATH, 'thumbnail')
+
+function testMigration (keys, t) {
+  var old = blobstore(MEDIA_PATH)
+  var safe = safeBlobstore(MEDIA_PATH)
+
+  var tasks = []
+  keys.forEach(function (key) {
+    tasks.push((next) => {
+      var testImage = path.join(TEST_IMAGES, key)
+      writeFile(testImage, 'original/' + key, function (err) {
+        t.error(err, 'error in writing orignal for ' + key)
+        writeFile(testImage, 'thumbnail/' + key, function (err) {
+          t.error(err, 'error in writing thumbnail for ' + key)
+          fs.access(path.join(ORIGINAL_PATH, key), function (err) {
+            t.error(err, 'test image exists in media path (original)')
+            fs.access(path.join(THUMBNAIL_PATH, key), function (err) {
+              t.error(err, 'test image exists in media path (thumbnail)')
+              next()
+            })
+          })
+        })
+      })
+    })
+  })
+
+  series(tasks, function (err) {
+    t.error(err)
+    migrateMedia(MEDIA_PATH, function (err) {
+      t.error(err, 'error on migrate')
+      keys.forEach(testKey)
+    })
+  })
+
+  function writeFile (testImage, key, cb) {
+    var readStream = fs.createReadStream(testImage)
+    var writeStream = old.createWriteStream(key, cb)
+    readStream.pipe(writeStream)
+  }
+
+  let pending = keys.length
+
+  function done () {
+    pending--
+    if (pending !== 0) return
+    t.end()
+  }
+
+  function testKey (key) {
+    var newFile = safe.createReadStream('original/' + key)
+    newFile.on('error', function (err) {
+      t.error(err, 'error on reading from safe blob store')
+      t.end()
+    })
+    newFile.pipe(concat(function (data) {
+      var testImage = path.join(TEST_IMAGES, key)
+      t.same(fs.readFileSync(testImage), data)
+      fs.access(path.join(ORIGINAL_PATH, key), function (err) {
+        t.ok(err, 'test image no longer exists in old blob store format (original)')
+        fs.access(path.join(THUMBNAIL_PATH, key), function (err) {
+          t.ok(err, 'test image no longer exists in old blob store format (thumbnail)')
+          done()
+        })
+      })
+    }))
+  }
+}
 
 test('migrates files', function (t) {
   resetMediaPath()
-  var original = blobstore(MEDIA_PATH)
-  var testImage = path.join(TEST_IMAGES, key)
-
-  function done (err) {
-    t.error(err)
-    fs.access(path.join(MEDIA_PATH, key), function (err) {
-      t.ok(err, 'test image no longer exists in old blob store format')
-      t.end()
-    })
-  }
-
-  function doMigrate (err) {
-    t.error(err)
-    fs.access(path.join(MEDIA_PATH, key), function (err) {
-      t.error(err, 'test image exists in media path')
-
-      migrateMedia(MEDIA_PATH, function (err) {
-        t.error(err, 'error on migrate')
-        var safe = safeBlobstore(MEDIA_PATH)
-        console.log(key)
-        var newFile = safe.createReadStream({key})
-        newFile.on('error', function (err) {
-          t.error(err, 'error on reading from safe blob store')
-          t.end()
-        })
-        newFile.pipe(concat(function (data) {
-          t.same(fs.readFileSync(testImage), data)
-          done()
-        }))
-      })
-    })
-  }
-
-  var readStream = fs.createReadStream(testImage)
-  var writeStream = original.createWriteStream({key}, doMigrate)
-  readStream.pipe(writeStream)
+  testMigration(['mapeo-icon.png'], t)
 })
 
-test('when there is nothing to migrate, nothing happens', function (t) {
-  // resetMediaPath()
-  migrateMedia(MEDIA_PATH, function (err) {
-    t.error(err, 'error on migrate')
-    t.end()
-  })
+test('when media folder has many items', function (t) {
+  resetMediaPath()
+  testMigration(['mapeo-icon.png', 'add-button.png'], t)
 })
 
 function resetMediaPath () {


### PR DESCRIPTION
This little PR migrates media blob stores from fs-blob-store to safe-fs-blob-store

If media is not migrated, then people using older versions of Mapeo Mobile (e.g., the version ECA has) who upgrade to the newest version will not be able to see or sync the images they've taken previously.
