### PR TITLE
fix(migration): use osm-p2p

### DIFF
--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -9,9 +9,7 @@
   "dependencies": {
     "bindings-noderify-nodejs-mobile": "^10.3.0",
     "debug": "^4.1.1",
-    "kappa-core": "^2.6.2",
-    "kappa-osm": "^3.0.1",
-    "level": "^4.0.0",
+    "osm-p2p": "^4.0.0",
     "mapeo-default-settings": "^2.0.0",
     "mapeo-server": "^15.0.0",
     "mkdirp": "^0.5.1",

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -1,9 +1,6 @@
 const http = require("http");
 const path = require("path");
-const level = require("level");
-const kappa = require("kappa-core");
-const raf = require("random-access-file");
-const createOsmDb = require("kappa-osm");
+const createOsmDb = require("osm-p2p");
 const createMediaStore = require("safe-fs-blob-store");
 const createMapeoRouter = require("mapeo-server");
 const debug = require("debug");
@@ -15,17 +12,6 @@ const log = debug("mapeo-core:server");
 module.exports = createServer;
 
 function createServer({ privateStorage, sharedStorage }) {
-  const indexDb = level(path.join(privateStorage, "index"));
-  const coreDb = kappa(path.join(privateStorage, "db"), {
-    valueEncoding: "json"
-  });
-  function createStorage(name, cb) {
-    process.nextTick(
-      cb,
-      null,
-      raf(path.join(privateStorage, "index", "bkd", name))
-    );
-  }
   // create folders for presets & styles
   mkdirp.sync(path.join(sharedStorage, "presets/default"));
   mkdirp.sync(path.join(sharedStorage, "styles/default"));
@@ -35,11 +21,7 @@ function createServer({ privateStorage, sharedStorage }) {
   const fallbackPresetsDir = path.join(process.cwd(), "presets");
 
   // The main osm db for observations and map data
-  const osm = createOsmDb({
-    core: coreDb,
-    index: indexDb,
-    storage: createStorage
-  });
+  const osm = createOsmDb(path.join(privateStorage, "data"));
 
   // The media store for photos, video etc.
   const media = createMediaStore(path.join(privateStorage, "media"));


### PR DESCRIPTION
The directory structure for the mobile app was different than the migration scripts and desktop. The `osm-p2p` module encapsulates the logic around where the internal leveldb for indexing and for kappa-core are stored on the filesystem. By using the same logic for all instances (migration, desktop, and mobile) it is more straightforward to copy data directly between these deployments without modifying the directory structure.