### PR TITLE
 fix: remove 64bit builds to fix Galaxy S7 issue with Android v7

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -114,7 +114,9 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
-
+        ndk {
+            abiFilters "armeabi-v7a", "x86"
+        }
         // Detox integration
         // testBuildType System.getProperty('testBuildType', 'debug')  //this will later be used to control the test apk build type
         // missingDimensionStrategy "minReactNative", "minReactNative46" //read note

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -125,7 +125,7 @@ android {
             reset()
             enable enableSeparateBuildPerCPUArchitecture
             universalApk false  // If true, also generate a universal APK
-            include "armeabi-v7a", "x86", "arm64-v8a"
+            include "armeabi-v7a", "x86"
         }
     }
     signingConfigs {
@@ -186,7 +186,7 @@ android {
         variant.outputs.each { output ->
             // For each separate APK per architecture, set a unique version code as described here:
             // http://tools.android.com/tech-docs/new-build-system/user-guide/apk-splits
-            def versionCodes = ["armeabi-v7a":1, "x86":2, "arm64-v8a": 3]
+            def versionCodes = ["armeabi-v7a":1, "x86":2]
             def abi = output.getFilter(OutputFile.ABI)
             if (abi != null) {  // null for the universal-debug, universal-release variants
                 output.versionCodeOverride =


### PR DESCRIPTION
The Play Store will stop accepting apps without 64-bit builds in August 2019, so this is a temporary fix. The underlying problem is with React Native and JSC and is specific to the S7 with Android 7, and a handful of other devices. Tracking issue upstream here: facebook/react-native#24261