### PR TITLE
Fix/manual coords error

### DIFF
--- a/src/frontend/lib/utils.js
+++ b/src/frontend/lib/utils.js
@@ -87,10 +87,17 @@ export function formatCoords({
   lat: number,
   format?: "utm"
 }): string {
-  let { easting, northing, zoneNum, zoneLetter } = fromLatLon(lat, lon);
-  easting = leftPad(easting.toFixed(), 6, "0");
-  northing = leftPad(northing.toFixed(), 6, "0");
-  return `UTM ${zoneNum}${zoneLetter} ${easting} ${northing}`;
+  try {
+    let { easting, northing, zoneNum, zoneLetter } = fromLatLon(lat, lon);
+    easting = leftPad(easting.toFixed(), 6, "0");
+    northing = leftPad(northing.toFixed(), 6, "0");
+    return `UTM ${zoneNum}${zoneLetter} ${easting} ${northing}`;
+  } catch (e) {
+    // Some coordinates (e.g. < 80S or 84N) cannot be formatted as UTM
+    return `${lat >= 0 ? "+" : ""}${lat.toFixed(6)}°, ${
+      lon >= 0 ? "+" : ""
+    }${lon.toFixed(6)}°`;
+  }
 }
 
 function leftPad(str: string, len: number, char: string): string {

--- a/src/frontend/screens/ManualGpsScreen.js
+++ b/src/frontend/screens/ManualGpsScreen.js
@@ -68,12 +68,57 @@ class ManualGpsScreen extends React.Component<Props, State> {
 
   toLatLon() {
     const { zoneNum, zoneLetter, easting, northing } = this.state;
+    const parsedNorthing = parseNumber(northing);
+    let northern;
+    // There are two conventions for UTM. One uses a letter to refer to latitude
+    // bands from C to X, excluding "I" and "O". The other uses "N" or "S" to
+    // refer to the northern or southern hemisphere. If the user enters "N" or
+    // "S" we do not know which convention they are using, so we guess. We try
+    // to use the latitude band if we can, since it is better for catching
+    // errors in coordinate entry.
+    if (zoneLetter === "S") {
+      // "S" could refer to grid zone "S" (in the northern hemisphere) or it
+      // could mean "Southern" - conventions differ in different places
+      const startOfZoneS = 3544369.909548157;
+      const startOfZoneT = 4432069.057005376;
+      if (
+        parsedNorthing !== undefined &&
+        parsedNorthing >= startOfZoneS &&
+        parsedNorthing < startOfZoneT
+      ) {
+        // Indeterminate, this could be latitude band S, or it could mean
+        // southern hemisphere. The only place in the southern hemisphere that
+        // matches these coordinates is the very southern tip of Chile and
+        // Argentina, so assume that in this case zoneLetter "S" refers to
+        // latitude band "S", in the northern hemisphere.
+        // TODO: Check with the user what they mean, or use last known location
+      } else {
+        // The northing is not within the range of grid zone "S", so we assume
+        // the user meant "Southern" with the letter "S"
+        northern = false;
+      }
+    } else if (zoneLetter === "N") {
+      const startOfZoneN = 0;
+      const startOfZoneP = 885503.7592863895;
+      if (
+        parsedNorthing &&
+        parsedNorthing >= startOfZoneN &&
+        parsedNorthing < startOfZoneP
+      ) {
+        // Definitely in latitude band N, just use the band letter
+      } else {
+        // Outside latitude band "N", so the user probably means "Northern"
+        northern = true;
+      }
+    }
     try {
       return toLatLon(
         parseNumber(easting),
         parseNumber(northing),
         parseNumber(zoneNum),
-        zoneLetter
+        // If northern defined, then don't use the zoneLetter.
+        northern !== undefined ? undefined : zoneLetter,
+        northern
       );
     } catch (err) {
       ToastAndroid.showWithGravity(
@@ -127,7 +172,7 @@ class ManualGpsScreen extends React.Component<Props, State> {
               placeholderTextColor="silver"
               underlineColorAndroid="transparent"
               onChangeText={zoneLetter =>
-                this.setState({ zoneLetter: zoneLetter.trim() })
+                this.setState({ zoneLetter: zoneLetter.trim().toUpperCase() })
               }
               maxLength={1}
               autoCapitalize="characters"


### PR DESCRIPTION
@jencastrodoesstuff discovered a bug when a user entered coordinates for zone "18S". In Peru, and many other places, "S" is used here to signify "southern hemisphere", however GPS often show the letter to mean [latitude band](https://en.wikipedia.org/wiki/Universal_Transverse_Mercator_coordinate_system#Latitude_bands_2), and latitude band "S" is in the north.

This fixes this by guessing what the user means when the enter "S". It checks whether the coordinates entered are within the range for latitude band "S" and if they are not then it assumes they mean "southern".

**WARNING**: This will cause confusing behaviour for latitudes between -58 and -50 south. The only land mass that this includes is the very southern tip of Chile and Argentina. If a user in this zone uses the zone letter "S" then the app will assume they mean northern latitude band "S". They can avoid this problem by entering the actual latitude band letter, which is "F" for this region.

TLDR; this will work as expected for all users except in the rare case of users in Tierra de la Fuego who use the N/S UTM convention as opposed to the latitude band letter convention.

This also fixes a bug that caused an app crash if coordinates were outside a range that can be converted to UTM (UTM only covers latitudes 80°S to 84°N).