### PR TITLE
Fix map zoom-out when switching back to map screen

### DIFF
--- a/src/frontend/sharedComponents/MapView.js
+++ b/src/frontend/sharedComponents/MapView.js
@@ -221,20 +221,18 @@ class MapView extends React.Component<Props, State> {
           styleURL={styleURL}
           onRegionDidChange={this.handleRegionDidChange}
         >
-          {isFocused && locationServicesEnabled && (
-            <MapboxGL.UserLocation visible />
+          {locationServicesEnabled && (
+            <MapboxGL.UserLocation visible={isFocused} />
           )}
-          {isFocused && (
-            <MapboxGL.Camera
-              centerCoordinate={initialCoords}
-              zoomLevel={initialZoom}
-              followUserLocation={this.state.following}
-              followUserMode="normal"
-              followZoomLevel={this.getFollowZoomLevel()}
-              animationMode="flyTo"
-              triggerKey={this.state.following}
-            />
-          )}
+          <MapboxGL.Camera
+            centerCoordinate={initialCoords}
+            zoomLevel={initialZoom}
+            followUserLocation={isFocused && this.state.following}
+            followUserMode="normal"
+            followZoomLevel={this.getFollowZoomLevel()}
+            animationMode="flyTo"
+            triggerKey={this.state.following}
+          />
           <ObservationMapLayer
             onPress={this.handleObservationPress}
             observations={observations}


### PR DESCRIPTION
@noffle reported this error, which happens when the map is not in "follow-mode" - e.g. when the map is not centered over the user location. If you switch away from the map screen and then return to it, it zooms out to zoom 8.

This fixes things, by keeping the MapCamera component mounted when the user navigates away from the map. It uses the navigation focus to turn off follow-mode when the user navigates away though, in order to reduce battery use. The map being in follow-mode and the display of the user location (blue dot) on the map has a significant impact on CPU/battery.