### PR TITLE
feat: Remove request for storage permissions

### DIFF
--- a/__mocks__/bugsnag-react-native.js
+++ b/__mocks__/bugsnag-react-native.js
@@ -1,0 +1,6 @@
+export const Client = () => ({
+  leaveBreadcrumb: () => {},
+  notify: () => {}
+});
+
+export const Configuration = () => ({});

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -5,8 +5,6 @@
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.CAMERA" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
   <application android:name=".MainApplication" 

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -63,10 +63,9 @@ status.startHeartbeat();
  * card. It is a shared folder that the user can access. The data folder
  * accessible through rnBridge.app.datadir() is not accessible by the user.
  *
- * The node process cannot request permission to read this folder and it does
- * not know the filepath. We need to wait for the React Native process to tell
- * us where the folder is. This code supports re-starting the server with a
- * different folder if necessary (we probably shouldn't do that)
+ * We need to wait for the React Native process to tell us where the folder is.
+ * This code supports re-starting the server with a different folder if
+ * necessary (we probably shouldn't do that)
  */
 rnBridge.channel.on("storagePath", path => {
   log("storagePath", path);

--- a/src/frontend/AppLoading.js
+++ b/src/frontend/AppLoading.js
@@ -42,9 +42,7 @@ class AppLoading extends React.Component<Props, State> {
     this.props.requestPermissions([
       PERMISSIONS.CAMERA,
       PERMISSIONS.ACCESS_COARSE_LOCATION,
-      PERMISSIONS.ACCESS_FINE_LOCATION,
-      PERMISSIONS.READ_EXTERNAL_STORAGE,
-      PERMISSIONS.WRITE_EXTERNAL_STORAGE
+      PERMISSIONS.ACCESS_FINE_LOCATION
     ]);
     this._timeoutId = setTimeout(() => {
       SplashScreen.hide();
@@ -55,7 +53,7 @@ class AppLoading extends React.Component<Props, State> {
   }
 
   componentDidUpdate() {
-    if (this.hasStoragePermission() && this.state.serverStatus == null) {
+    if (this.state.serverStatus == null) {
       api.startServer();
       this.setState({ serverStatus: Constants.STARTING });
     }
@@ -66,15 +64,6 @@ class AppLoading extends React.Component<Props, State> {
     if (!this._timeoutId) return;
     clearTimeout(this._timeoutId);
     SplashScreen.hide();
-  }
-
-  hasStoragePermission() {
-    // $FlowFixMe - needs HOC type to be fixed
-    const { permissions } = this.props;
-    return (
-      permissions[PERMISSIONS.READ_EXTERNAL_STORAGE] === RESULTS.GRANTED &&
-      permissions[PERMISSIONS.WRITE_EXTERNAL_STORAGE] === RESULTS.GRANTED
-    );
   }
 
   handleStatusChange = (serverStatus: ServerStatus) => {

--- a/src/frontend/context/PermissionsContext.js
+++ b/src/frontend/context/PermissionsContext.js
@@ -14,9 +14,7 @@ export type PermissionResult = "granted" | "denied" | "never_ask_again";
 type PermissionType =
   | "android.permission.CAMERA"
   | "android.permission.ACCESS_FINE_LOCATION"
-  | "android.permission.ACCESS_COARSE_LOCATION"
-  | "android.permission.READ_EXTERNAL_STORAGE"
-  | "android.permission.WRITE_EXTERNAL_STORAGE";
+  | "android.permission.ACCESS_COARSE_LOCATION";
 
 export type PermissionsType = {|
   [PermissionType]: PermissionResult
@@ -31,9 +29,7 @@ export const RESULTS: { [string]: PermissionResult } = {
 export const PERMISSIONS: { [string]: PermissionType } = {
   CAMERA: "android.permission.CAMERA",
   ACCESS_FINE_LOCATION: "android.permission.ACCESS_FINE_LOCATION",
-  ACCESS_COARSE_LOCATION: "android.permission.ACCESS_COARSE_LOCATION",
-  READ_EXTERNAL_STORAGE: "android.permission.READ_EXTERNAL_STORAGE",
-  WRITE_EXTERNAL_STORAGE: "android.permission.WRITE_EXTERNAL_STORAGE"
+  ACCESS_COARSE_LOCATION: "android.permission.ACCESS_COARSE_LOCATION"
 };
 
 type RequestPermissions = (type: PermissionType | PermissionType[]) => any;


### PR DESCRIPTION
It turns out Android does not need extra permissions for accessing files in external storage which are in the folder returned by getExternalFilesDir() https://developer.android.com/reference/android/content/Context.html#getExternalFilesDir(java.lang.String)