### PR TITLE
feat: Allow select_one options to be deselected

### DIFF
--- a/src/frontend/screens/Observation/ObservationView.js
+++ b/src/frontend/screens/Observation/ObservationView.js
@@ -142,6 +142,8 @@ const Button = ({ onPress, color, iconName, title }: ButtonProps) => (
 
 const FieldView = ({ label, answer, style }) => {
   const { formatMessage: t } = useIntl();
+  // Select multiple answers are an array, so we join them with commas
+  const formattedAnswer = Array.isArray(answer) ? answer.join(", ") : answer;
   return (
     <View style={style}>
       <Text style={styles.fieldTitle}>{label}</Text>
@@ -150,7 +152,7 @@ const FieldView = ({ label, answer, style }) => {
           styles.fieldAnswer,
           { color: answer === undefined ? MEDIUM_GREY : DARK_GREY }
         ]}>
-        {answer || t(m.noAnswer)}
+        {formattedAnswer || t(m.noAnswer)}
       </Text>
     </View>
   );

--- a/src/frontend/screens/ObservationDetails/Question.js
+++ b/src/frontend/screens/ObservationDetails/Question.js
@@ -2,6 +2,7 @@
 import React from "react";
 
 import SelectOne from "./SelectOne";
+import SelectMultiple from "./SelectMultiple";
 import TextArea from "./TextArea";
 
 import type { Field } from "../../context/PresetsContext";
@@ -17,6 +18,8 @@ const Question = (props: QuestionProps) => {
   const { field, ...other } = props;
   if (field.type === "select_one" && Array.isArray(field.options)) {
     return <SelectOne {...other} field={field} />;
+  } else if (field.type === "select_multiple" && Array.isArray(field.options)) {
+    return <SelectMultiple {...other} field={field} />;
   } else return <TextArea {...props} />;
 };
 

--- a/src/frontend/screens/ObservationDetails/SelectMultiple.js
+++ b/src/frontend/screens/ObservationDetails/SelectMultiple.js
@@ -1,0 +1,124 @@
+// @flow
+import React from "react";
+import { View, StyleSheet, Text } from "react-native";
+import MaterialIcon from "react-native-vector-icons/MaterialIcons";
+
+import { TouchableNativeFeedback } from "../../sharedComponents/Touchables";
+import { VERY_LIGHT_BLUE } from "../../lib/styles";
+
+import type { Style } from "../../types";
+import type { QuestionProps } from "./Question";
+import type { SelectField } from "../../context/PresetsContext";
+
+type Props = {
+  ...$Exact<QuestionProps>,
+  field: SelectField
+};
+
+type CheckItemProps = {
+  checked: boolean,
+  onPress: () => any,
+  label: string,
+  style: Style<typeof View>
+};
+
+const CheckItem = ({ checked, onPress, label, style }: CheckItemProps) => (
+  <TouchableNativeFeedback
+    onPress={onPress}
+    background={TouchableNativeFeedback.Ripple(VERY_LIGHT_BLUE, false)}>
+    <View style={style}>
+      <MaterialIcon
+        name={checked ? "check-box" : "check-box-outline-blank"}
+        size={30}
+      />
+      <Text style={styles.itemLabel}>{label}</Text>
+    </View>
+  </TouchableNativeFeedback>
+);
+
+const SelectMultiple = ({
+  value,
+  field: { placeholder, label, options },
+  onChange
+}: Props) => {
+  const valueAsArray = toArray(value);
+
+  const handleChange = itemValue => {
+    console.log("prev Value", valueAsArray);
+    const updatedValue = valueAsArray.includes(itemValue)
+      ? valueAsArray.filter(d => d !== itemValue)
+      : [...valueAsArray, itemValue];
+    console.log("new Value", updatedValue);
+    onChange(updatedValue);
+  };
+
+  return (
+    <>
+      <View style={styles.labelContainer}>
+        <Text style={styles.label}>{label}</Text>
+        {placeholder && <Text style={styles.hint}>{placeholder}</Text>}
+      </View>
+      {options.map(convertItem).map((item, index) => (
+        <CheckItem
+          key={item.value}
+          onPress={() => handleChange(item.value)}
+          checked={valueAsArray.includes(item.value)}
+          label={item.label}
+          style={[styles.radioContainer, index === 0 ? styles.noBorder : {}]}
+        />
+      ))}
+    </>
+  );
+};
+
+function toArray(value) {
+  // null or undefined
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+export default React.memo<Props>(SelectMultiple);
+
+// We allow select options to be an array of strings, or objects with values and
+// labels
+function convertItem(item): { value: number | string, label: string } {
+  if (typeof item !== "string" && typeof item !== "number") return item;
+  return { value: item, label: item + "" };
+}
+
+const styles = StyleSheet.create({
+  labelContainer: {
+    flex: 0,
+    padding: 20,
+    borderBottomWidth: 2,
+    borderColor: "#F3F3F3"
+  },
+  label: {
+    fontSize: 20,
+    color: "black",
+    fontWeight: "700"
+  },
+  hint: {
+    fontSize: 12,
+    color: "#A9A9A9",
+    fontWeight: "700"
+  },
+  radioContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 20,
+    marginLeft: 20,
+    paddingRight: 20,
+    borderTopWidth: 1,
+    borderColor: "#F3F3F3"
+  },
+  noBorder: {
+    borderTopWidth: 0
+  },
+  itemLabel: {
+    fontSize: 18,
+    marginLeft: 20,
+    color: "black",
+    fontWeight: "700"
+  }
+});

--- a/src/frontend/screens/ObservationDetails/SelectOne.js
+++ b/src/frontend/screens/ObservationDetails/SelectOne.js
@@ -25,8 +25,7 @@ type RadioItemProps = {
 const RadioItem = ({ checked, onPress, label, style }: RadioItemProps) => (
   <TouchableNativeFeedback
     onPress={onPress}
-    background={TouchableNativeFeedback.Ripple(VERY_LIGHT_BLUE, false)}
-  >
+    background={TouchableNativeFeedback.Ripple(VERY_LIGHT_BLUE, false)}>
     <View style={style}>
       <MaterialIcon
         name={checked ? "radio-button-checked" : "radio-button-unchecked"}
@@ -50,7 +49,7 @@ const SelectOne = ({
     {options.map(convertItem).map((item, index) => (
       <RadioItem
         key={item.value}
-        onPress={() => onChange(item.value)}
+        onPress={() => onChange(value === item.value ? null : item.value)}
         checked={item.value === value}
         label={item.label}
         style={[styles.radioContainer, index === 0 ? styles.noBorder : {}]}


### PR DESCRIPTION
Previously once you had selected an option from a select_one question it was not possible to change it back to no option (e.g. unanswered)

In the future we want to have a "N/A" option which deselects, since this toggling radio buttons is not standard UX