### PR TITLE
feat: Device name remains the same across app restarts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23649,6 +23649,11 @@
       "resolved": "https://registry.npmjs.org/react-native-build-config/-/react-native-build-config-0.3.2.tgz",
       "integrity": "sha512-yGWzeJNR1m0Cml6grVEnE/5/5dcKvDLmnubJkA/6Tt5P/40JAgrtjwEnC8NifhLIKZ1rEzbL/inIh/m7qkvEtg=="
     },
+    "react-native-device-info": {
+      "version": "5.5.4",
+      "resolved": "https://registry.npmjs.org/react-native-device-info/-/react-native-device-info-5.5.4.tgz",
+      "integrity": "sha512-koR7ZvL4V+34GwhjQxb3PNZLElpEzAvDG5AE4KIc70ufKMEHJL9VCpRXBMelihlA0u9PlYzuMgBs7tovNRAzFw=="
+    },
     "react-native-fs": {
       "version": "2.16.6",
       "resolved": "https://registry.npmjs.org/react-native-fs/-/react-native-fs-2.16.6.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "react-native": "0.62.2",
     "react-native-android-open-settings": "^1.3.0",
     "react-native-build-config": "^0.3.2",
+    "react-native-device-info": "^5.5.4",
     "react-native-fs": "^2.16.6",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-image-resizer": "^1.2.1",

--- a/src/frontend/screens/SyncModal/index.js
+++ b/src/frontend/screens/SyncModal/index.js
@@ -13,6 +13,7 @@ import { NetworkInfo } from "react-native-network-info";
 import OpenSettings from "react-native-android-open-settings";
 import KeepAwake from "react-native-keep-awake";
 import { defineMessages, useIntl, FormattedMessage } from "react-intl";
+import { getUniqueId } from "react-native-device-info";
 
 import SyncView from "./SyncView";
 import api from "../../api";
@@ -72,8 +73,7 @@ const m = defineMessages({
 
 const deviceName: string =
   "Android " +
-  Math.floor(Math.random() * 1e9)
-    .toString(36)
+  getUniqueId()
     .slice(0, 4)
     .toUpperCase();
 


### PR DESCRIPTION
Currently the device name is a random string that is generated each app restart. This change uses the unique device ID, which ensures the default generated device name does not change for a particular device.