### PR TITLE
fix: Fix observations not rendering when GPS is off

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4124,9 +4124,9 @@
       "integrity": "sha512-IkzS78nOiPNM/MboBqqbk2eMBrflp8VML/p33pd50KZq+PvBq8Oywt1JKOgdaMxUIbGjP73zVz+f6r2f80u2Eg=="
     },
     "@react-native-mapbox-gl/maps": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@react-native-mapbox-gl/maps/-/maps-8.0.0.tgz",
-      "integrity": "sha512-anOYwSpqFG2JyY8d9uxYH01cBUIo1/osXlC7hD5LJTC6x8nUPpn7/k7TGjH7kgrCtYxpqXI1G7nWPYUwyA1j/w==",
+      "version": "8.1.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@react-native-mapbox-gl/maps/-/maps-8.1.0-rc.2.tgz",
+      "integrity": "sha512-gjU5YSjlxqWZ5flMxiEoKUsu9DjLy3aqntivJGbqooRT8d1wILtErXDG2TDyprWGrUpFUl/D27TjLLSIhVmyOw==",
       "requires": {
         "@mapbox/geo-viewport": ">= 0.4.0",
         "@turf/along": ">= 4.0.0 <7.0.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@react-native-community/async-storage": "^1.8.1",
     "@react-native-community/hooks": "^2.4.7",
     "@react-native-community/netinfo": "^5.6.2",
-    "@react-native-mapbox-gl/maps": "^8.0.0",
+    "@react-native-mapbox-gl/maps": "^8.1.0-rc.2",
     "bugsnag-react-native": "^2.21.0",
     "cheap-ruler": "^2.5.1",
     "core-js": "^3.1.4",

--- a/src/frontend/sharedComponents/MapView.js
+++ b/src/frontend/sharedComponents/MapView.js
@@ -137,7 +137,11 @@ class MapView extends React.Component<Props, State> {
       following:
         !!props.location.provider &&
         props.location.provider.locationServicesEnabled,
-      zoom: 12,
+      zoom:
+        props.location.provider &&
+        props.location.provider.locationServicesEnabled
+          ? 12
+          : 0.1,
       coords: getCoords(props.location)
     };
 
@@ -148,11 +152,12 @@ class MapView extends React.Component<Props, State> {
     MapboxGL.setTelemetryEnabled(false);
   }
 
-  // We only use the location prop (which contains the app GPS location) for the
-  // first render of the map. After that location updates come from the native
-  // map view, so we don't want to re-render this component every time there is
-  // a GPS update, only when the location provider status changes, which we use
-  // to render the map in follow-mode or not.
+  // Instead of using <MapboxGL.Camera> for following user location (because it
+  // causes CPU usage to rise to 150% because it frequently re-renders the map)
+  // we update the coordinates of the map every time the location changes by
+  // more than MIN_DISPLACEMENT meters. When the coords update,
+  // <MapboxGL.Camera> (in non-follow-mode) will animate a transition to the new
+  // location
   shouldComponentUpdate(nextProps: Props, nextState: State) {
     // Don't update the map at all if the map is not the active screen
     if (!nextProps.isFocused) return false;
@@ -207,7 +212,6 @@ class MapView extends React.Component<Props, State> {
 
   handleRegionWillChange = (e: any) => {
     if (!e.properties.isUserInteraction || !this.state.following) return;
-    // Any user interaction with the map switches follow mode to false
     this.setState({ following: false });
   };
 
@@ -234,6 +238,7 @@ class MapView extends React.Component<Props, State> {
   handleLocationPress = () => {
     const { location } = this.props;
     if (!(location.provider && location.provider.locationServicesEnabled))
+      // TODO: Show alert for the user here so they know why it does not work
       return;
     this.setState(state => ({ following: !state.following }));
   };
@@ -287,30 +292,33 @@ class MapView extends React.Component<Props, State> {
             onRegionWillChange={this.handleRegionWillChange}
             onRegionIsChanging={this.handleRegionIsChanging}
             onRegionDidChange={this.handleRegionDidChange}>
-            {following && (
-              <MapboxGL.Camera
-                defaultSettings={{
-                  centerCoordinate: this.coordsRef || coords || [0, 0],
-                  zoomLevel: this.zoomRef || zoom
-                }}
-                animationDuration={1000}
-                centerCoordinate={getCoords(location)}
-                zoomLevel={
-                  (this.zoomRef || zoom) < 12 ? 12 : this.zoomRef || zoom
-                }
-                animationMode="flyTo"
+            <MapboxGL.Camera
+              defaultSettings={{
+                centerCoordinate: this.coordsRef || coords || [0, 0],
+                zoomLevel: this.zoomRef || zoom || 12
+              }}
+              centerCoordinate={following ? getCoords(location) : undefined}
+              zoomLevel={
+                !following
+                  ? undefined
+                  : (this.zoomRef || zoom) < 12
+                  ? 12
+                  : this.zoomRef || zoom
+              }
+              animationDuration={1000}
+              animationMode="flyTo"
+              followUserLocation={false}
+            />
+            {this.state.hasFinishedLoadingStyle && (
+              <ObservationMapLayer
+                onPress={this.handleObservationPress}
+                observations={observations}
               />
             )}
             {locationServicesEnabled && (
               <MapboxGL.UserLocation
                 visible={isFocused}
                 minDisplacement={MIN_DISPLACEMENT}
-              />
-            )}
-            {this.state.hasFinishedLoadingStyle && (
-              <ObservationMapLayer
-                onPress={this.handleObservationPress}
-                observations={observations}
               />
             )}
           </MapboxGL.MapView>


### PR DESCRIPTION
Previously, <MapboxGL.Camera> was not rendered when location services
were off. This caused the <MapboxGL.ShapeSource> to not render (for
unknown reasons). This fix always renders MapboxGL.Camera and ignores
location updates if the map is not in follow mode.

Fixes #430