### PR TITLE
feat: Accessibility labels for buttons and form fields

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -50,6 +50,10 @@
   "screens.AddPhoto.cancel": {
     "message": "Cancel"
   },
+  "screens.CameraScreen.createObservationAccessibilityLabel": {
+    "description": "Accessibility label for screen readers for \"Create Observation\" button on camera screen",
+    "message": "Create Observation with photo"
+  },
   "screens.CameraScreen.noCameraAccess": {
     "description": "Error message shown when app does not have permissions to camera",
     "message": "No access to camera"
@@ -111,6 +115,10 @@
   },
   "screens.ManualGpsScreen.zoneNumber": {
     "message": "Zone Number"
+  },
+  "screens.MapScreen.createObservationAccessibilityLabel": {
+    "description": "Accessibility label for screen readers for \"Create Observation\" button on map screen",
+    "message": "Create Observation"
   },
   "screens.Observation.ObservationView.alertFooter": {
     "description": "Footer for shared observations message",
@@ -423,7 +431,27 @@
   "sharedComponents.GpsPill.noGps": {
     "message": "No GPS"
   },
+  "sharedComponents.GpsPill.openGpsAccessibilityLabel": {
+    "description": "Accessibility label for button to open GPS screen",
+    "message": "Open GPS screen"
+  },
   "sharedComponents.GpsPill.searching": {
     "message": "Searching…"
+  },
+  "sharedComponents.HomeHeader.openObservationListAccessibilityLabel": {
+    "description": "Accessibility label for button to open Observation list screen",
+    "message": "View Observations"
+  },
+  "sharedComponents.HomeHeader.openSyncAccessibilityLabel": {
+    "description": "Accessibility label for button to open sync screen",
+    "message": "Open sync screen"
+  },
+  "sharedComponents.ThumbnailScrollView.photoAccessibilityHint": {
+    "description": "Accessibility hint for screen readers for clicking a photo thumbnail from observation view",
+    "message": "Tap to view full-size photograph"
+  },
+  "sharedComponents.ThumbnailScrollView.photoAccessibilityLabel": {
+    "description": "Accessibility label for screen readers for a photo thumbnail in the view of an observation",
+    "message": "A photograph"
   }
 }

--- a/src/frontend/screens/MapScreen.js
+++ b/src/frontend/screens/MapScreen.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from "react";
 import { View, Text } from "react-native";
+import { defineMessages, useIntl } from "react-intl";
 
 import debug from "debug";
 
@@ -15,6 +16,15 @@ import type { NavigationProp } from "../types";
 
 const log = debug("mapeo:MapScreen");
 
+const msgs = defineMessages({
+  createObservation: {
+    id: "screens.MapScreen.createObservationAccessibilityLabel",
+    defaultMessage: "Create Observation",
+    description:
+      'Accessibility label for screen readers for "Create Observation" button on map screen',
+  },
+});
+
 type Props = {
   navigation: NavigationProp,
 };
@@ -22,6 +32,7 @@ type Props = {
 const MapScreen = ({ navigation }: Props) => {
   const [, { newDraft }] = useDraftObservation();
   const { styleURL, styleType } = useMapStyle();
+  const { formatMessage } = useIntl();
 
   const [{ observations, status }] = React.useContext(ObservationsContext);
   const location = React.useContext(LocationContext);
@@ -56,7 +67,12 @@ const MapScreen = ({ navigation }: Props) => {
           styleType={styleType}
         />
       )}
-      <AddButton testID="addButtonMap" onPress={handleAddPress} />
+      <AddButton
+        testID="addButtonMap"
+        accessible={true}
+        accessibilityLabel={formatMessage(msgs.createObservation)}
+        onPress={handleAddPress}
+      />
     </View>
   );
 };

--- a/src/frontend/screens/ObservationDetails/TextArea.js
+++ b/src/frontend/screens/ObservationDetails/TextArea.js
@@ -1,24 +1,33 @@
 // @flow
 import React from "react";
 import { StyleSheet, TextInput } from "react-native";
+import { useIntl } from "react-intl";
+import { formatFieldProp } from "../../sharedComponents/FormattedData";
 import QuestionLabel from "./QuestionLabel";
 
 import type { QuestionProps } from "./Question";
 
-const TextArea = ({ value, field, onChange }: QuestionProps) => (
-  <>
-    <QuestionLabel field={field} />
-    <TextInput
-      value={value}
-      onChangeText={onChange}
-      style={styles.textInput}
-      underlineColorAndroid="transparent"
-      multiline
-      scrollEnabled={false}
-      textContentType="none"
-    />
-  </>
-);
+const TextArea = ({ value, field, onChange }: QuestionProps) => {
+  const intl = useIntl();
+  return (
+    <>
+      <QuestionLabel field={field} />
+      <TextInput
+        value={value}
+        onChangeText={onChange}
+        accessible={true}
+        accessibilityLabel={formatFieldProp(field, "label", intl)}
+        accessibilityHint={formatFieldProp(field, "placeholder", intl)}
+        placeholder={formatFieldProp(field, "placeholder", intl)}
+        style={styles.textInput}
+        underlineColorAndroid="transparent"
+        multiline
+        scrollEnabled={false}
+        textContentType="none"
+      />
+    </>
+  );
+};
 
 export default React.memo<QuestionProps>(TextArea);
 

--- a/src/frontend/sharedComponents/CameraView.js
+++ b/src/frontend/sharedComponents/CameraView.js
@@ -6,6 +6,7 @@ import debug from "debug";
 import { Accelerometer } from "expo-sensors";
 import ImageResizer from "react-native-image-resizer";
 import RNFS from "react-native-fs";
+import { defineMessages, useIntl } from "react-intl";
 
 import AddButton from "./AddButton";
 import { promiseTimeout } from "../lib/utils";
@@ -14,6 +15,15 @@ import type { CapturedPictureMM } from "../hooks/useDraftObservation";
 import useIsMounted from "../hooks/useIsMounted";
 
 const log = debug("CameraView");
+
+const msgs = defineMessages({
+  createObservation: {
+    id: "screens.CameraScreen.createObservationAccessibilityLabel",
+    defaultMessage: "Create Observation with photo",
+    description:
+      'Accessibility label for screen readers for "Create Observation" button on camera screen',
+  },
+});
 
 const captureQuality = 75;
 const captureOptions = {
@@ -35,6 +45,7 @@ type Props = {
 type Acceleration = { x: number, y: number, z: number };
 
 const CameraView = ({ onAddPress }: Props) => {
+  const { formatMessage } = useIntl();
   const ref = React.useRef();
   const acceleration = React.useRef();
   const isMounted = useIsMounted();
@@ -117,6 +128,8 @@ const CameraView = ({ onAddPress }: Props) => {
       />
       <AddButton
         onPress={handleAddPress}
+        accessible={true}
+        accessibilityLabel={formatMessage(msgs.createObservation)}
         style={{ opacity: capturing ? 0.5 : 1 }}
         testID="addButtonCamera"
       />

--- a/src/frontend/sharedComponents/FormattedData.js
+++ b/src/frontend/sharedComponents/FormattedData.js
@@ -33,6 +33,8 @@ export const FormattedCoords = ({ lat, lon }: { lat: number, lon: number }) => {
   return <>{formatCoords({ lon, lat })}</>;
 };
 
+type FieldPropName = "label" | "placeholder" | "helperText";
+
 // Render the translated value of a translatable Field property (one of
 // `label`, `placeholder` or `helperText`). `label` will always render
 // something: if it is undefined or an empty string, then it will use the field
@@ -43,11 +45,22 @@ export const FormattedFieldProp = ({
   propName,
 }: {
   field: Field,
-  propName: "label" | "placeholder" | "helperText",
+  propName: FieldPropName,
 }) => {
-  const { formatMessage: t } = useIntl();
+  const intl = useIntl();
+  const value = formatFieldProp(field, propName, intl);
+  if (!value) return null;
+  return <>{value}</>;
+};
+
+export function formatFieldProp(
+  field: Field,
+  propName: FieldPropName,
+  intl: any
+) {
+  const { formatMessage: t } = intl;
   const fieldKey = Array.isArray(field.key) ? field.key[0] : field.key;
-  const value = field[propName]
+  return field[propName]
     ? t({
         id: `fields.${field.id}.${propName}`,
         defaultMessage: field[propName],
@@ -56,9 +69,7 @@ export const FormattedFieldProp = ({
     propName === "label"
     ? fieldKey
     : undefined;
-  if (!value) return null;
-  return <>{value}</>;
-};
+}
 
 // Render a field value as a string. If the value is an array, convert to string
 // and join with `, `. If the field is a select_one or select_multiple field,
@@ -75,7 +86,14 @@ export const FormattedFieldValue = ({
   value: any,
   field: Field,
 |}) => {
-  const { formatMessage: t } = useIntl();
+  const intl = useIntl();
+  const formattedValue = formatFieldValue(field, value, intl);
+
+  return <>{formattedValue}</>;
+};
+
+export function formatFieldValue(field: Field, value: any, intl: any) {
+  const { formatMessage: t } = intl;
   // Select multiple answers are an array, so we join them with commas
   const formattedValue = (Array.isArray(value) ? value : [value])
     // Filter any undefined values or empty strings (an empty string can come
@@ -90,8 +108,8 @@ export const FormattedFieldValue = ({
     .join(", ");
   // This will return a noAnswer string if formattedValue is undefined or an
   // empty string
-  return <>{formattedValue || t(m.noAnswer)}</>;
-};
+  return formattedValue || t(m.noAnswer);
+}
 
 // Format the created_at date of an observation as either a datetime, or a
 // relative datetime (e.g. "3 minutes ago")
@@ -120,13 +138,21 @@ export const FormattedPresetName = ({
 }: {|
   preset: Preset | PresetWithFields | void,
 |}) => {
-  const { formatMessage: t } = useIntl();
-  const name = preset
-    ? t({ id: `presets.${preset.id}.name`, defaultMessage: preset.name })
-    : t(m.observation);
+  const intl = useIntl();
+  const name = formatPresetName(preset, intl);
 
   return <>{name}</>;
 };
+
+export function formatPresetName(
+  preset: Preset | PresetWithFields | void,
+  intl: any
+) {
+  const { formatMessage: t } = intl;
+  return preset
+    ? t({ id: `presets.${preset.id}.name`, defaultMessage: preset.name })
+    : t(m.observation);
+}
 
 // TODO: Better hangling of boolean and null values (we don't create these
 // anywhere yet)

--- a/src/frontend/sharedComponents/GpsPill.js
+++ b/src/frontend/sharedComponents/GpsPill.js
@@ -18,6 +18,11 @@ const m = defineMessages({
     id: "sharedComponents.GpsPill.searching",
     defaultMessage: "Searching…",
   },
+  openGps: {
+    id: "sharedComponents.GpsPill.openGpsAccessibilityLabel",
+    defaultMessage: "Open GPS screen",
+    description: "Accessibility label for button to open GPS screen",
+  },
 });
 
 const ERROR_COLOR = "#FF0000";
@@ -38,7 +43,12 @@ export const GpsPill = React.memo<Props>(
       text = t(m.searching);
     else text = `± ${precision} m`;
     return (
-      <TouchableOpacity onPress={onPress} testID="gpsPillButton">
+      <TouchableOpacity
+        accessible={true}
+        accessibilityLabel={t(m.openGps)}
+        onPress={onPress}
+        testID="gpsPillButton"
+      >
         <View
           style={[
             styles.container,

--- a/src/frontend/sharedComponents/HomeHeader.js
+++ b/src/frontend/sharedComponents/HomeHeader.js
@@ -2,13 +2,30 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import LinearGradient from "react-native-linear-gradient";
+import { defineMessages, useIntl } from "react-intl";
+
 import type { NavigationProp } from "../types";
 
 import IconButton from "../sharedComponents/IconButton";
 import { ObservationListIcon, SyncIconCircle } from "../sharedComponents/icons";
 import GpsPill from "../sharedComponents/GpsPill";
 
+const msgs = defineMessages({
+  openSync: {
+    id: "sharedComponents.HomeHeader.openSyncAccessibilityLabel",
+    defaultMessage: "Open sync screen",
+    description: "Accessibility label for button to open sync screen",
+  },
+  openObservationList: {
+    id: "sharedComponents.HomeHeader.openObservationListAccessibilityLabel",
+    defaultMessage: "View Observations",
+    description:
+      "Accessibility label for button to open Observation list screen",
+  },
+});
+
 const HomeHeader = ({ navigation }: { navigation: NavigationProp }) => {
+  const { formatMessage } = useIntl();
   const gradient = ( // $FlowFixMe - https://github.com/react-native-community/react-native-linear-gradient/issues/385
     <LinearGradient style={styles.linearGradient} colors={["#0006", "#0000"]} />
   );
@@ -17,6 +34,8 @@ const HomeHeader = ({ navigation }: { navigation: NavigationProp }) => {
       {gradient}
       <IconButton
         style={styles.leftButton}
+        accessible={true}
+        accessibilityLabel={formatMessage(msgs.openSync)}
         onPress={() => {
           navigation.navigate("SyncModal");
         }}
@@ -30,6 +49,8 @@ const HomeHeader = ({ navigation }: { navigation: NavigationProp }) => {
       />
       <IconButton
         style={styles.rightButton}
+        accessible={true}
+        accessibilityLabel={formatMessage(msgs.openObservationList)}
         onPress={() => {
           navigation.navigate("ObservationList");
         }}

--- a/src/frontend/sharedComponents/IconButton.js
+++ b/src/frontend/sharedComponents/IconButton.js
@@ -18,13 +18,24 @@ type Props = {
   style?: ViewStyleProp,
   children: React.Node,
   testID?: string,
+  accessibilityLabel?: string,
+  accessible?: boolean,
 };
 
-const IconButton = ({ onPress, style, children, testID }: Props) => (
+const IconButton = ({
+  onPress,
+  style,
+  children,
+  testID,
+  accessibilityLabel,
+  accessible,
+}: Props) => (
   <TouchableNativeFeedback
     testID={testID}
     onPress={onPress}
     background={TouchableNativeFeedback.Ripple(VERY_LIGHT_BLUE, true)}
+    accessible={accessible}
+    accessibilityLabel={accessibilityLabel}
   >
     <View style={[styles.container, style]}>{children}</View>
   </TouchableNativeFeedback>


### PR DESCRIPTION
Add accessibility labels and hints for buttons and form fields. Contributions welcome.

- [x] Observation additional details --> Text input
- [x] Observation attached photo thumbnails
- [x] Create observation button on map and camera tabs
- [x] Sync, GPS and Observation navigation buttons in header on home screen
- [ ] Buttons in Sync screen
- [ ] Buttons in Observation view (edit, share, delete)
- [ ] Buttons in Observation edit (save, add photo, add details, question navigation)
- [ ] Category icon buttons
- [ ] Back buttons throughout

If you would like to see better accessibility support in Mapeo you may help out by adding accessibility labels to items in the todo list above and sending a pull request.
