### PR TITLE
chore(CI): Update JDK setup action

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Node
         uses: actions/setup-node@v1
       - name: Use specific Java version for sdkmanager to work
-        uses: joschi/setup-jdk@v1
+        uses: joschi/setup-jdk@v2
         with:
           java-version: "openjdk8"
           architecture: "x64"


### PR DESCRIPTION
 joschi/setup-jdk@v1 does not seem to be working any more.