### PR TITLE
fix: Fix import config button crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapeo-mobile",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/frontend/screens/Settings/ProjectConfig.js
+++ b/src/frontend/screens/Settings/ProjectConfig.js
@@ -124,7 +124,7 @@ const ProjectConfig = () => {
         variant="outlined"
         onPress={handleImportPress}
       >
-        <FormattedMessage {...m.importConfig} />
+        {t(m.importConfig) /* Button component expects string children */}
       </Button>
     </View>
   );

--- a/src/frontend/sharedComponents/Button.js
+++ b/src/frontend/sharedComponents/Button.js
@@ -57,13 +57,16 @@ const Button = ({
         onPress={disabled ? undefined : onPress}
       >
         <View style={styles.touchable}>
-          {typeof children === "string" ? (
-            <Text style={[styles.textBase, textStyle]}>
-              {children.toUpperCase()}
-            </Text>
-          ) : (
-            children
-          )}
+          {
+            typeof children === "string" ? (
+              <Text style={[styles.textBase, textStyle]}>
+                {children.toUpperCase()}
+              </Text>
+            ) : (
+              children
+            )
+            // TODO: Handle <FormattedMessage> as children (wrapping in <Text>)
+          }
         </View>
       </TouchableNativeFeedback>
     </View>


### PR DESCRIPTION
The `<Button>` component currently expects children to be a string, so it doesn't wrap `<FormattedMessage>` in a `<Text>` component. We need to fix `<Button>` but this is a short-term fix.