### PR TITLE
chore: Update NDK version [WIP]

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -32,7 +32,12 @@ jobs:
       - name: Update sdkmanager
         run: sdkmanager --update | grep -v = || true
       - name: Install correct NDK
-        run: echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${ANDROID_NDK_VERSION}" --sdk_root=${ANDROID_SDK_ROOT}
+        run: |
+          # Delete other NDK versions, because CMake seems tried to use them
+          rm -rf ${ANDROID_HOME}/ndk-bundle
+          rm -rf ${ANDROID_HOME}/ndk/*
+          # Install supported version of NDK
+          echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${ANDROID_NDK_VERSION}" --sdk_root=${ANDROID_SDK_ROOT}
       - name: Check Env
         run: |
           ls -al ${ANDROID_HOME}/ndk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -4,6 +4,8 @@ jobs:
   build:
     name: e2e tests
     runs-on: macos-latest
+    env:
+      ANDROID_NDK_VERSION: "21.3.6528147"
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,8 +33,11 @@ jobs:
         run: sdkmanager --update | grep -v = || true
       - name: Install correct NDK
         run: echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${ANDROID_NDK_VERSION}" --sdk_root=${ANDROID_SDK_ROOT}
-        env:
-          ANDROID_NDK_VERSION: "21.3.6528147"
+      - name: Check Env
+        run: |
+          ls -al ${ANDROID_HOME}/ndk
+          ls -al ${ANDROID_HOME}
+          echo ${ANDROID_NDK_HOME}
       - name: Download Android Emulator Image
         run: |
           echo "Downloading emulator image"
@@ -60,6 +65,7 @@ jobs:
           npm run build:translations
       - name: Build for detox
         run: |
+          export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
           npm run build-detox-android
       - name: Android Emulator
         timeout-minutes: 10

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Build for detox
         run: |
           export ANDROID_NDK_HOME=$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION
+          export ANDROID_NDK_ROOT=$ANDROID_NDK_HOME
           npm run build-detox-android
       - name: Android Emulator
         timeout-minutes: 10

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Update sdkmanager
         run: sdkmanager --update | grep -v = || true
       - name: Install correct NDK
-        run: sdkmanager --install "ndk;${ANDROID_NDK_VERSION}"
+        run: echo "y" | ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;${ANDROID_NDK_VERSION}" --sdk_root=${ANDROID_SDK_ROOT}
         env:
           ANDROID_NDK_VERSION: "21.3.6528147"
       - name: Download Android Emulator Image

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,21 +27,14 @@ jobs:
         with:
           java-version: "openjdk8"
           architecture: "x64"
-      # - name: Install NDK
-      #   run: |
-      #     export ANDROID_NDK_VERSION='20b'
-      #     export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
-      #     curl -fsSo android-ndk-r${ANDROID_NDK_VERSION}.zip https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.zip
-      #     unzip -q -o android-ndk-r${ANDROID_NDK_VERSION}.zip
-      #     rm -rf $ANDROID_NDK_HOME
-      #     mv android-ndk-r${ANDROID_NDK_VERSION} $ANDROID_NDK_HOME
-      #     ls -al $ANDROID_NDK_HOME
-      #     cat $ANDROID_NDK_HOME/source.properties
+      - name: Update sdkmanager
+        run: sdkmanager --update | grep -v = || true
+      - name: Install correct NDK
+        run: sdkmanager --install "ndk;${ANDROID_NDK_VERSION}"
+        env:
+          ANDROID_NDK_VERSION: "21.3.6528147"
       - name: Download Android Emulator Image
         run: |
-          sdkmanager --update | grep -v = || true
-          echo "SDK versions:"
-          $ANDROID_HOME/tools/bin/sdkmanager --list
           echo "Downloading emulator image"
           echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-28;default;x86" > /dev/null
           echo "Creating emulator avd"
@@ -53,6 +46,8 @@ jobs:
           kextstat | grep intel
           echo "\nEmulator config"
           cat $HOME/.android/avd/emu.avd/config.ini
+      - name: List SDK versions
+        run: $ANDROID_HOME/tools/bin/sdkmanager --list
       - name: Install node_modules
         run: |
           mkdir -p nodejs-assets

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         supportLibVersion = "29.0.0"
         // Kotlin is needed by Detox testing framework
         kotlinVersion = "1.3.50"
-        ndkVersion = "21.3.6528147"
+        ndkVersion = "21.4.7075529"
     }
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         supportLibVersion = "29.0.0"
         // Kotlin is needed by Detox testing framework
         kotlinVersion = "1.3.50"
-        ndkVersion = "21.4.7075529"
+        ndkVersion = "21.3.6528147"
     }
     repositories {
         google()


### PR DESCRIPTION
Looks like Github has updated their images to NDK 21.4.7075529. We could install our version as part of the build process, but testing to see if builds work in this newer NDK version.