### PR TITLE
Add additional config available for UpgradeManager instance

### DIFF
--- a/android/app/src/main/java/com/mapeo/AppInfoModule.java
+++ b/android/app/src/main/java/com/mapeo/AppInfoModule.java
@@ -14,10 +14,6 @@ import java.util.HashMap;
 public class AppInfoModule extends ReactContextBaseJavaModule {
   private static ReactApplicationContext reactContext;
 
-  static final String MODULE_NAME = "AppInfo";
-
-  private static final String sourceDir = "sourceDir";
-
   AppInfoModule(ReactApplicationContext context) {
     super(context);
     reactContext = context;
@@ -25,14 +21,15 @@ public class AppInfoModule extends ReactContextBaseJavaModule {
 
   @Override
   public String getName() {
-    return MODULE_NAME;
+    return "AppInfo";
   }
 
   @Override
   public Map<String, Object> getConstants() {
     final Map<String, Object> constants = new HashMap<>();
     ApplicationInfo ai = getReactApplicationContext().getApplicationInfo();
-    constants.put(sourceDir, ai.sourceDir);
+    constants.put("sourceDir", ai.sourceDir);
+    constants.put("minSdkVersion", ai.minSdkVersion);
     return constants;
   }
 }

--- a/android/app/src/main/java/com/mapeo/MainApplication.java
+++ b/android/app/src/main/java/com/mapeo/MainApplication.java
@@ -7,6 +7,7 @@ import com.facebook.react.PackageList;
 import com.facebook.hermes.reactexecutor.HermesExecutorFactory;
 import com.facebook.react.bridge.JavaScriptExecutorFactory;
 import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
 import com.bugsnag.BugsnagReactNative;
 import cl.json.ShareApplication;
 import com.facebook.react.ReactNativeHost;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapeo-mobile",
-  "version": "5.0.3",
+  "version": "5.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -86,7 +86,6 @@ rnBridge.channel.on("config", config => {
     server = createServer({
       privateStorage: rnBridge.app.datadir(),
       sharedStorage: storagePath,
-      upgradeStorage: config.upgradeStoragePath,
     });
   } catch (error) {
     status.setState(constants.ERROR, { error, context: "createServer" });

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -36,7 +36,6 @@ const releaseStage = prereleaseComponents
 const log = debug("mapeo-core:index");
 const PORT = 9081;
 const status = new ServerStatus();
-let storagePath;
 let server;
 
 // This is nastily circular: we need an instance of status for the constructor
@@ -69,23 +68,20 @@ status.startHeartbeat();
  * accessible through rnBridge.app.datadir() is not accessible by the user.
  *
  * We need to wait for the React Native process to tell us where the folder is.
- * This code supports re-starting the server with a different folder if
- * necessary (we probably shouldn't do that)
  */
-rnBridge.channel.on("config", config => {
-  log("storagePath", config.storagePath);
-  if (config.storagePath === storagePath) return;
-  const prevStoragePath = storagePath;
-  if (server)
-    stopServer(() => {
-      log(`closed server with:
-  storagePath: ${prevStoragePath}`);
-    });
-  storagePath = config.storagePath;
+rnBridge.channel.once("config", config => {
+  log("config", config);
+  if (server) {
+    const error = new Error(
+      "Server already existed when config event was received"
+    );
+    status.setState(constants.ERROR, { error, context: "config" });
+    return;
+  }
   try {
     server = createServer({
       privateStorage: rnBridge.app.datadir(),
-      sharedStorage: storagePath,
+      sharedStorage: config.storagePath,
     });
   } catch (error) {
     status.setState(constants.ERROR, { error, context: "createServer" });
@@ -121,7 +117,11 @@ rnBridge.app.on("resume", () => {
 const noop = () => {};
 
 function startServer() {
-  if (!server) return;
+  if (!server) {
+    const error = new Error("Tried to start server before config was received");
+    status.setState(constants.ERROR, { error, context: "createServer" });
+    return;
+  }
   const state = status.getState();
   if (state === constants.CLOSING) {
     log("Server was closing when it tried to start");

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -67,6 +67,9 @@ status.startHeartbeat();
  * card. It is a shared folder that the user can access. The data folder
  * accessible through rnBridge.app.datadir() is not accessible by the user.
  *
+ * Other config data such as the path to the APK file is only available in the
+ * React Native process, so we pass that to the backend here
+ *
  * We need to wait for the React Native process to tell us where the folder is.
  */
 rnBridge.channel.once("config", config => {
@@ -82,6 +85,7 @@ rnBridge.channel.once("config", config => {
     server = createServer({
       privateStorage: rnBridge.app.datadir(),
       sharedStorage: config.storagePath,
+      ...config,
     });
   } catch (error) {
     status.setState(constants.ERROR, { error, context: "createServer" });

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -30,7 +30,6 @@ module.exports = createServer;
 function createServer({
   privateStorage,
   sharedStorage,
-  upgradeStorage,
   flavor,
 }) {
   const defaultConfigPath = path.join(sharedStorage, "presets/default");
@@ -68,7 +67,7 @@ function createServer({
   });
   let mapeoCore = mapeoRouter.api.core;
 
-  const upgradePath = path.join(upgradeStorage, "upgrades");
+  const upgradePath = path.join(privateStorage, "upgrades");
   mkdirp.sync(upgradePath);
   let upgradeManager;
 

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -30,7 +30,6 @@ module.exports = createServer;
 function createServer({
   privateStorage,
   sharedStorage,
-  flavor,
 }) {
   const defaultConfigPath = path.join(sharedStorage, "presets/default");
   log("Creating server");

--- a/src/backend/server.js
+++ b/src/backend/server.js
@@ -30,6 +30,11 @@ module.exports = createServer;
 function createServer({
   privateStorage,
   sharedStorage,
+  apkPath,
+  minSdkVersion,
+  version,
+  buildNumber,
+  bundleId,
 }) {
   const defaultConfigPath = path.join(sharedStorage, "presets/default");
   log("Creating server");
@@ -183,6 +188,7 @@ function createServer({
       const emitFn = rnBridge.channel.post.bind(rnBridge.channel);
       const listenFn = rnBridge.channel.on.bind(rnBridge.channel);
       const removeFn = rnBridge.channel.removeListener.bind(rnBridge.channel);
+      // TODO: Pass apkPath, version, buildNumber, minSdkVersion, bundleId
       upgradeManager = new UpgradeManager(
         upgradePath,
         port,

--- a/src/backend/status.js
+++ b/src/backend/status.js
@@ -33,7 +33,7 @@ class ServerStatus {
     if (this.state === constants.ERROR) return;
     if (nextState === constants.ERROR) {
       error = error || new Error("Unknown server error");
-      log(error.message);
+      log(context, error.message);
       main.bugsnag.notify(error, { context });
     }
     this.state = nextState;

--- a/src/frontend/api.js
+++ b/src/frontend/api.js
@@ -238,7 +238,6 @@ export function Api({
         // other config that the server requires
         nodejs.channel.post("config", {
           storagePath: RNFS.ExternalDirectoryPath,
-          upgradeStoragePath: RNFS.DocumentDirectoryPath,
         });
         // Resolve once the server reports status as "LISTENING"
         return onReady();

--- a/src/frontend/api.js
+++ b/src/frontend/api.js
@@ -237,7 +237,12 @@ export function Api({
         // As soon as we hear from the Node process, send the storagePath and
         // other config that the server requires
         nodejs.channel.post("config", {
-          storagePath: RNFS.ExternalDirectoryPath,
+          sharedStorage: RNFS.ExternalDirectoryPath,
+          apkPath: AppInfo.sourceDir,
+          minSdkVersion: AppInfo.minSdkVersion,
+          version: DeviceInfo.getVersion(),
+          buildNumber: DeviceInfo.getBuildNumber(),
+          bundleId: DeviceInfo.getBundleId(),
         });
         // Resolve once the server reports status as "LISTENING"
         return onReady();

--- a/src/frontend/lib/AppInfo.js
+++ b/src/frontend/lib/AppInfo.js
@@ -1,2 +1,10 @@
 import { NativeModules } from "react-native";
-export default NativeModules.AppInfo;
+
+/**
+ * @type {object}
+ * @property {string} sourceDir Full path to the base APK for this application.
+ * @property {string} minSdkVersion The minimum SDK version this application can run on. It will not run on earlier versions.
+ */
+const constants = NativeModules.AppInfo.getConstants();
+
+export default constants;


### PR DESCRIPTION
I also did a few cleanup tasks here.

This makes the following variables available for the creation of the UpgradeManager instance:

- `apkPath`: Path to currently running APK (file can be read from nodejs)
- `minSdkVersion`: Min Android SDK version supported by currently running APK
- `version`: Version name of running APK (semver if release, but not if testing)
- `buildNumber`: Increments every time CI build happens - must always increase
- `bundleId`: Different variants have different bundleIds
    - com.mapeo
    - com.mapeo.qa
    - com.mapeo.debug
    - com.mapeo.icca
  Different bundle ids install as separate apps

