### PR TITLE
chore: change to semver version names

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -238,7 +238,6 @@ android {
         qa {
             dimension "version"
             applicationIdSuffix ".qa"
-            versionNameSuffix "-QA"
         }
         app {
             dimension "version"
@@ -246,7 +245,6 @@ android {
         icca {
             dimension "version"
             applicationIdSuffix ".icca"
-            versionNameSuffix "-ICCA"
         }
     }
     buildTypes {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -196,7 +196,7 @@ android {
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode myVersionCode
-        versionName getenv("ANDROID_VERSION_NAME") ?: "0.0.0"
+        versionName getenv("ANDROID_VERSION_NAME") ?: getenv("npm_package_version") ?: "0.0.0"
         archivesBaseName = "mapeo"
 
         // Detox integration

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -387,13 +387,24 @@ workflows:
                 if [[ "$BITRISE_GIT_BRANCH" == "deploy" || -n "$BITRISE_GIT_TAG" ]]; then
                     # This is a push to deploy event or a tag event
                     # Pushing a tag to Github for some reason triggers this workflow with $BITRISE_GIT_BRANCH set to master
-                    ANDROID_VERSION_NAME="${VERSION_NAME}.${BITRISE_BUILD_NUMBER}"
+                    ANDROID_VERSION_NAME="${VERSION_NAME}"
                 elif [ "${BITRISE_GIT_BRANCH%/*}" == "release" ]; then
                     # This is a push to a branch matching `release/*`, so we build a release candidate
-                    ANDROID_VERSION_NAME="${VERSION_NAME}-RC.${BITRISE_BUILD_NUMBER}"
+                    ANDROID_VERSION_NAME="${VERSION_NAME}-RC"
+                    if [ -n "${BITRISE_GIT_COMMIT}" ]; then
+                        ANDROID_VERSION_NAME+="+${BITRISE_GIT_COMMIT:0:7}"
+                    fi
                 else
                     # This is an internal build
-                    ANDROID_VERSION_NAME="Internal.${BITRISE_BUILD_NUMBER}"
+                    ANDROID_VERSION_NAME="${VERSION_NAME}"
+                    if [ -n "${BITRISE_PULL_REQUEST}" ]; then
+                        ANDROID_VERSION_NAME+="-PR${BITRISE_PULL_REQUEST}"
+                    else
+                        ANDROID_VERSION_NAME+="-internal"
+                    fi
+                    if [ -n "${BITRISE_GIT_COMMIT}" ]; then
+                        ANDROID_VERSION_NAME+="+${BITRISE_GIT_COMMIT:0:7}"
+                    fi
                 fi
 
                 envman add --key VERSION_NAME --value $VERSION_NAME

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -32,22 +32,46 @@ workflows:
       - script@1.1.6:
           title: Rename APKs
           inputs:
-            - content:
-                "#!/usr/bin/env bash\n\n# Renames the apks with the current datetime
-                and a \n# reference the git commit and the bitrise build slug\n\nset -eE
-                -o pipefail\nshopt -s extdebug\n\n# Split the path_list variable by |
-                into an array\nIFS='|' read -r -a paths <<< \"$BITRISE_APK_PATH_LIST\"\nnew_paths=()\ndatestring=$(date
-                -u +\"%Y%m%d_%H%M%S\")\n\nfor path in \"${paths[@]}\"\ndo\n  # Just the
-                path portion\n  dir=\"${path%/*}\"\n  # Just the filename without extensions\n
-                \ basename=\"${path##*/}\"\n  basename=\"${basename%.apk*}\"\n  # Construct
-                path with new filename\n  new_path=\"${dir}/${datestring}-${basename}\"\n
-                \ if [ -n \"${BITRISE_PULL_REQUEST}\" ]; then\n    new_path+=\"_PR#${BITRISE_PULL_REQUEST}\"\n
-                \ fi\n  if [ -n \"${BITRISE_GIT_COMMIT}\" ]; then\n    new_path+=\"_${BITRISE_GIT_COMMIT:0:7}\"\n
-                \ fi\n  new_path+=\".apk\"\n  mv \"$path\" \"$new_path\"\n  echo \"Moved
-                ${path} --> ${new_path}\"\n  new_paths+=(\"$new_path\")\ndone\n\n# Join
-                the path_list array into a string separated by |\nIFS=\\| eval 'NEW_APK_PATH_LIST=\"${new_paths[*]}\"'\n\n#
-                Save the variable to the env so it is accessible in other build steps\nenvman
-                add --key BITRISE_APK_PATH_LIST --value \"$NEW_APK_PATH_LIST\"\n"
+            - content: |
+                #!/usr/bin/env bash
+
+                # Renames the apks with the current datetime and a
+                # reference the git commit and the bitrise build slug
+
+                set -eE -o pipefail
+                shopt -s extdebug
+
+                # Split the path_list variable by | into an array
+                IFS='|' read -r -a paths <<< "$BITRISE_APK_PATH_LIST"
+                new_paths=()
+                datestring=$(date -u +"%Y%m%d_%H%M%S")""
+
+                for path in "${paths[@]}"
+                do
+                  # Just the path portion
+                  dir="${path%/*}"
+                  # Just the filename without extensions
+                  basename="${path##*/}"
+                  basename="${basename%.apk*}"
+                  # Construct path with new filename
+                  new_path="${dir}/${datestring}-${basename}"
+                  if [ -n "${BITRISE_PULL_REQUEST}" ]; then
+                    new_path+="_PR#${BITRISE_PULL_REQUEST}"
+                  fi
+                  if [ -n "${BITRISE_GIT_COMMIT}" ]; then
+                    new_path+="_${BITRISE_GIT_COMMIT:0:7}"
+                  fi
+                  new_path+=".apk"
+                  mv "$path" "$new_path"
+                  echo "Moved ${path} --> ${new_path}"
+                  new_paths+=("$new_path")
+                done
+
+                # Join the path_list array into a string separated by |
+                IFS='|' eval 'NEW_APK_PATH_LIST="${new_paths[*]}"'
+
+                # Save the variable to the env so it is accessible in other build steps
+                envman add --key BITRISE_APK_PATH_LIST --value "$NEW_APK_PATH_LIST"
       - deploy-to-bitrise-io@1.9.6: {}
     meta:
       bitrise.io: null
@@ -64,27 +88,49 @@ workflows:
       - script@1.1.6:
           title: Rename APKs
           inputs:
-            - content:
-                "#!/usr/bin/env bash\n\n# Renames the apks with the current datetime
-                and a \n# reference the git commit and the bitrise build slug\n\nset -eE
-                -o pipefail\nshopt -s extdebug\n\n# Split the path_list variable by |
-                into an array\nIFS='|' read -r -a paths <<< \"$BITRISE_APK_PATH_LIST\"\nnew_paths=()\n\nfor
-                path in \"${paths[@]}\"\ndo\n  # Just the path portion\n  dir=\"${path%/*}\"\n
-                \ # Just the filename\n  filename=\"${path##*/}\"\n  # Add version name\n
-                \ filename=\"${filename/mapeo-/mapeo-v$ANDROID_VERSION_NAME-}\"\n  # Uppercase
-                flavor or remove\n  filename=\"${filename/-qa-/-QA-}\"\n  filename=\"${filename/-icca-release/-ICCA}\"\n
-                \ filename=\"${filename/-app-release/}\"\n  filename=\"${filename/-app-/-}\"\n
-                \ # Construct path with new filename\n  new_path=\"${dir}/${filename}\"\n
-                \ mv \"$path\" \"$new_path\"\n  echo \"Moved ${path} --> ${new_path}\"\n
-                \ new_paths+=(\"$new_path\")\ndone\n\n# Join the path_list array into
-                a string separated by |\nIFS=\\| eval 'NEW_APK_PATH_LIST=\"${new_paths[*]}\"'\n\n#
-                Save the variable to the env so it is accessible in other build steps\nenvman
-                add --key BITRISE_APK_PATH_LIST --value \"$NEW_APK_PATH_LIST\"\n"
+            - content: |
+                #!/usr/bin/env bash
+
+                # Renames the apks with the current datetime and a
+                # reference the git commit and the bitrise build slug
+
+                set -eE -o pipefail
+                shopt -s extdebug
+
+                # Split the path_list variable by | into an array
+                IFS='|' read -r -a paths <<< "$BITRISE_APK_PATH_LIST"
+                new_paths=()
+
+                for path in "${paths[@]}"
+                do
+                  # Just the path portion
+                  dir="${path%/*}"
+                  # Just the filename
+                  filename="${path##*/}"
+                  # Add version name
+                  filename="${filename/mapeo-/mapeo-v$ANDROID_VERSION_NAME-}"
+                  # Uppercase flavor or remove
+                  filename="${filename/-qa-/-QA-}"
+                  filename="${filename/-icca-release/-ICCA}"
+                  filename="${filename/-app-release/}"
+                  filename="${filename/-app-/-}"
+                  # Construct path with new filename
+                  new_path="${dir}/${filename}"
+                  mv "$path" "$new_path"
+                  echo "Moved ${path} --> ${new_path}"
+                  new_paths+=("$new_path")
+                done
+
+                # Join the path_list array into a string separated by | char
+                IFS='|' eval 'NEW_APK_PATH_LIST="${new_paths[*]}"'
+
+                # Save the variable to the env so it is accessible in other build steps
+                envman add --key BITRISE_APK_PATH_LIST --value "$NEW_APK_PATH_LIST"
       - deploy-to-bitrise-io@1.9.6: {}
       - script@1.1.6:
           title: Set APK path variables
           inputs:
-            - content: |-
+            - content: |
                 #!/usr/bin/env bash
                 # fail if any commands fails
                 set -e
@@ -188,25 +234,47 @@ workflows:
       - script@1.1.6:
           title: Rename APKs
           inputs:
-            - content:
-                "#!/usr/bin/env bash\n\n# Renames the apks with the current datetime
-                and a \n# reference the git commit and the bitrise build slug\n\nset -eE
-                -o pipefail\nshopt -s extdebug\n\n# Split the path_list variable by |
-                into an array\nIFS='|' read -r -a paths <<< \"$BITRISE_APK_PATH_LIST\"\nnew_paths=()\n\nfor
-                path in \"${paths[@]}\"\ndo\n  # Just the path portion\n  dir=\"${path%/*}\"\n
-                \ # Just the filename\n  filename=\"${path##*/}\"\n  # Add version name\n
-                \ filename=\"${filename/mapeo-/mapeo-v$ANDROID_VERSION_NAME-}\"\n  # Uppercase
-                flavor or remove\n  filename=\"${filename/-qa-/-QA-}\"\n  filename=\"${filename/-icca-/-ICCA-}\"\n
-                \ filename=\"${filename/-app-/-}\"\n  # Construct path with new filename\n
-                \ new_path=\"${dir}/${filename}\"\n  mv \"$path\" \"$new_path\"\n  echo
-                \"Moved ${path} --> ${new_path}\"\n  new_paths+=(\"$new_path\")\ndone\n\n#
-                Join the path_list array into a string separated by |\nIFS=\\| eval 'NEW_APK_PATH_LIST=\"${new_paths[*]}\"'\n\n#
-                Save the variable to the env so it is accessible in other build steps\nenvman
-                add --key BITRISE_APK_PATH_LIST --value \"$NEW_APK_PATH_LIST\"\n"
+            - content: |
+                #!/usr/bin/env bash
+
+                # Renames the apks with the current datetime and a
+                # reference the git commit and the bitrise build slug
+
+                set -eE -o pipefail
+                shopt -s extdebug
+
+                # Split the path_list variable by | into an array
+                IFS='|' read -r -a paths <<< "$BITRISE_APK_PATH_LIST"
+                new_paths=()
+
+                for path in "${paths[@]}"
+                do
+                  # Just the path portion
+                  dir="${path%/*}"
+                  # Just the filename
+                  filename="${path##*/}"
+                  # Add version name
+                  filename="${filename/mapeo-/mapeo-v$ANDROID_VERSION_NAME-}"
+                  # Uppercase flavor or remove
+                  filename="${filename/-qa-/-QA-}"
+                  filename="${filename/-icca-/-ICCA-}"
+                  filename="${filename/-app-/-}"
+                  # Construct path with new filename
+                  new_path="${dir}/${filename}"
+                  mv "$path" "$new_path"
+                  echo "Moved ${path} --> ${new_path}"
+                  new_paths+=("$new_path")
+                done
+
+                # Join the path_list array into a string separated by |
+                IFS=\\| eval 'NEW_APK_PATH_LIST="${new_paths[*]}"'
+
+                # Save the variable to the env so it is accessible in other build steps
+                envman add --key BITRISE_APK_PATH_LIST --value "$NEW_APK_PATH_LIST"
       - script@1.1.6:
           title: Set APK path variables
           inputs:
-            - content: |-
+            - content: |
                 #!/usr/bin/env bash
                 # fail if any commands fails
                 set -e

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -254,7 +254,7 @@ workflows:
                   # Just the filename
                   filename="${path##*/}"
                   # Add version name
-                  filename="${filename/mapeo-/mapeo-v$ANDROID_VERSION_NAME-}"
+                  filename="${filename/mapeo-/mapeo-v$ANDROID_VERSION_NAME.$BITRISE_BUILD_NUMBER-}"
                   # Uppercase flavor or remove
                   filename="${filename/-qa-/-QA-}"
                   filename="${filename/-icca-/-ICCA-}"

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -56,7 +56,7 @@ workflows:
                   # Construct path with new filename
                   new_path="${dir}/${datestring}-${basename}"
                   if [ -n "${BITRISE_PULL_REQUEST}" ]; then
-                    new_path+="_PR#${BITRISE_PULL_REQUEST}"
+                    new_path+="_PR${BITRISE_PULL_REQUEST}"
                   fi
                   if [ -n "${BITRISE_GIT_COMMIT}" ]; then
                     new_path+="_${BITRISE_GIT_COMMIT:0:7}"

--- a/src/frontend/screens/Settings/AboutMapeo.js
+++ b/src/frontend/screens/Settings/AboutMapeo.js
@@ -17,10 +17,16 @@ const m = defineMessages({
     defaultMessage: "Mapeo version",
     description: "Label for Mapeo version",
   },
+  mapeoBuild: {
+    id: "screens.AboutMapeo.mapeoBuild",
+    defaultMessage: "Mapeo build",
+    description: "Label for Mapeo build number",
+  },
   mapeoType: {
     id: "screens.AboutMapeo.mapeoType",
-    defaultMessage: "Mapeo type",
-    description: "Label for Mapeo type",
+    defaultMessage: "Mapeo variant",
+    description:
+      "Label for Mapeo type/variant (e.g. QA for testing vs normal version of app)",
   },
   androidVersion: {
     id: "screens.AboutMapeo.androidVersion",
@@ -78,7 +84,8 @@ const DeviceInfoListItem = ({
 const AboutMapeo = () => {
   return (
     <List>
-      <DeviceInfoListItem label="Mapeo version" deviceProp="readableVersion" />
+      <DeviceInfoListItem label="Mapeo version" deviceProp="version" />
+      <DeviceInfoListItem label="Mapeo build" deviceProp="buildNumber" />
       <DeviceInfoListItem label="Mapeo type" deviceProp="bundleId" />
       <DeviceInfoListItem label="Android version" deviceProp="systemVersion" />
       <DeviceInfoListItem label="Android build" deviceProp="buildId" />


### PR DESCRIPTION
Fixes #554

Also separates version name from build number on the "About Mapeo" screen (rather than concatenating them as `versionName + "." + buildNumber`), so that there is clarity about the distinction between the two.

### Testing plan

Testing changes to the CI build scripts is tricky, because we need to check deployment, but we don't want to actually deploy anything. I have created [a fork](https://github.com/gmaclennan/mapeo-mobile) and a [test app on Bitrise](https://app.bitrise.io/app/0593ce51989160c7#) linked to the forked repo, so that I can go through all deployment steps to check that these changes work as planned:

- [x] Check a PR against `deploy` branch creates a QA build with the correct version name: https://app.bitrise.io/build/cec588b2ca22edc0#?tab=log
- [x] Check pushes to a `release/*` branch generate a RC build with the correct version name.
- [x] Check tag pushes to the `deploy` branch generate a production build with the correct version name.
