### PR TITLE
fix: Internationalize labels on "About Mapeo" screen

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -27,9 +27,13 @@
     "description": "Label for Android version",
     "message": "Android version"
   },
+  "screens.AboutMapeo.mapeoBuild": {
+    "description": "Label for Mapeo build number",
+    "message": "Mapeo build"
+  },
   "screens.AboutMapeo.mapeoType": {
-    "description": "Label for Mapeo type",
-    "message": "Mapeo type"
+    "description": "Label for Mapeo type/variant (e.g. QA for testing vs normal version of app)",
+    "message": "Mapeo variant"
   },
   "screens.AboutMapeo.mapeoVersion": {
     "description": "Label for Mapeo version",

--- a/src/frontend/screens/Settings/AboutMapeo.js
+++ b/src/frontend/screens/Settings/AboutMapeo.js
@@ -82,14 +82,18 @@ const DeviceInfoListItem = ({
 };
 
 const AboutMapeo = () => {
+  const { formatMessage: t } = useIntl();
   return (
     <List>
-      <DeviceInfoListItem label="Mapeo version" deviceProp="version" />
-      <DeviceInfoListItem label="Mapeo build" deviceProp="buildNumber" />
-      <DeviceInfoListItem label="Mapeo type" deviceProp="bundleId" />
-      <DeviceInfoListItem label="Android version" deviceProp="systemVersion" />
-      <DeviceInfoListItem label="Android build" deviceProp="buildId" />
-      <DeviceInfoListItem label="Phone model" deviceProp="model" />
+      <DeviceInfoListItem label={t(m.mapeoVersion)} deviceProp="version" />
+      <DeviceInfoListItem label={t(m.mapeoBuild)} deviceProp="buildNumber" />
+      <DeviceInfoListItem label={t(m.mapeoType)} deviceProp="bundleId" />
+      <DeviceInfoListItem
+        label={t(m.androidVersion)}
+        deviceProp="systemVersion"
+      />
+      <DeviceInfoListItem label={t(m.androidBuild)} deviceProp="buildId" />
+      <DeviceInfoListItem label={t(m.phoneModel)} deviceProp="model" />
     </List>
   );
 };


### PR DESCRIPTION
The labels of the sections on the "About Mapeo" screen were not correctly internationalized, so translated strings would not show up.

Wait on #557 before merging, since this PR branches from that (which also changes the About Mapeo screen).