### PR TITLE
Opt-in setting for p2p upgrades

### DIFF
--- a/src/frontend/AppStack.js
+++ b/src/frontend/AppStack.js
@@ -22,6 +22,7 @@ import ProjectConfig from "./screens/Settings/ProjectConfig";
 import AboutMapeo from "./screens/Settings/AboutMapeo";
 import LanguageSettings from "./screens/Settings/LanguageSettings";
 import CoordinateFormat from "./screens/Settings/CoordinateFormat";
+import Experiments from "./screens/Settings/Experiments";
 import HomeHeader from "./sharedComponents/HomeHeader";
 
 const HomeTabs = createBottomTabNavigator(
@@ -70,6 +71,8 @@ const AppStack = createStackNavigator(
     LanguageSettings,
     // $FlowFixMe
     CoordinateFormat,
+    // $FlowFixMe
+    Experiments,
     // $FlowFixMe
     PhotosModal: PhotosModal,
     // $FlowFixMe

--- a/src/frontend/context/SettingsContext.js
+++ b/src/frontend/context/SettingsContext.js
@@ -7,7 +7,7 @@ import createPersistedState from "../hooks/usePersistedState";
 const STORE_KEY = "@MapeoSettings@1";
 
 export type CoordinateFormat = "utm" | "dd" | "dms";
-export type ExperimentalP2pUpgrade = Boolean;
+export type ExperimentalP2pUpgrade = boolean;
 
 export type SettingsState = {
   coordinateFormat: CoordinateFormat,

--- a/src/frontend/context/SettingsContext.js
+++ b/src/frontend/context/SettingsContext.js
@@ -11,7 +11,9 @@ export type ExperimentalP2pUpgrade = boolean;
 
 export type SettingsState = {
   coordinateFormat: CoordinateFormat,
-  experimentalP2pUpgrade: ExperimentalP2pUpgrade,
+  experiments: {
+    p2pUpgrade: boolean,
+  },
 };
 
 type SettingsContextType = [
@@ -21,7 +23,9 @@ type SettingsContextType = [
 
 const DEFAULT_SETTINGS = {
   coordinateFormat: "utm",
-  experimentalP2pUpgrade: false,
+  experiments: {
+    p2pUpgrade: false,
+  },
 };
 
 const SettingsContext = React.createContext<SettingsContextType>([
@@ -37,6 +41,7 @@ export const SettingsProvider = ({ children }: { children: React.Node }) => {
   );
 
   const setSettings = React.useCallback(
+    // $FlowFixMe This is not broken, Flow is just wrong: https://medium.com/flow-type/spreads-common-errors-fixes-9701012e9d58 #timetoswitchtoTS
     (key, value) => setState({ ...state, [key]: value }),
     [setState, state]
   );

--- a/src/frontend/context/SettingsContext.js
+++ b/src/frontend/context/SettingsContext.js
@@ -7,9 +7,11 @@ import createPersistedState from "../hooks/usePersistedState";
 const STORE_KEY = "@MapeoSettings@1";
 
 export type CoordinateFormat = "utm" | "dd" | "dms";
+export type ExperimentalP2pUpgrade = Boolean;
 
 export type SettingsState = {
   coordinateFormat: CoordinateFormat,
+  experimentalP2pUpgrade: ExperimentalP2pUpgrade,
 };
 
 type SettingsContextType = [
@@ -19,6 +21,7 @@ type SettingsContextType = [
 
 const DEFAULT_SETTINGS = {
   coordinateFormat: "utm",
+  experimentalP2pUpgrade: false,
 };
 
 const SettingsContext = React.createContext<SettingsContextType>([

--- a/src/frontend/screens/Settings/Experiments.js
+++ b/src/frontend/screens/Settings/Experiments.js
@@ -26,7 +26,7 @@ const Experiments = () => {
   const [{ experiments }, setSettings] = React.useContext(SettingsContext);
 
   return (
-    <List testID="settingsList">
+    <List testID="experimentsList">
       <ListItem
         onPress={() =>
           setSettings("experiments", {
@@ -34,7 +34,7 @@ const Experiments = () => {
             p2pUpgrade: !experiments.p2pUpgrade,
           })
         }
-        testID="settingsLanguageButton"
+        testID="p2pUpgradeExperimentButton"
       >
         <ListItemIcon
           iconName={

--- a/src/frontend/screens/Settings/Experiments.js
+++ b/src/frontend/screens/Settings/Experiments.js
@@ -1,0 +1,52 @@
+// @flow
+import React from "react";
+import { defineMessages, FormattedMessage } from "react-intl";
+import SettingsContext from "../../context/SettingsContext";
+import {
+  List,
+  ListItem,
+  ListItemText,
+  ListItemIcon,
+} from "../../sharedComponents/List";
+
+const m = defineMessages({
+  p2pUpgrades: {
+    id: "screens.Settings.Experiments.p2pUpgrades",
+    defaultMessage: "P2P upgrades",
+    description: "Label for p2p upgrades",
+  },
+  p2pUpgradesDesc: {
+    id: "screens.Settings.Experiments.p2pUpgradesDesc",
+    defaultMessage: "Share and receive updates with nearby devices",
+    description: "Label for p2p upgrades description",
+  },
+});
+
+const Experiments = () => {
+  const [{ experimentalP2pUpgrade }, setSettings] = React.useContext(
+    SettingsContext
+  );
+
+  return (
+    <List testID="settingsList">
+      <ListItem
+        onPress={() =>
+          setSettings("experimentalP2pUpgrade", !experimentalP2pUpgrade)
+        }
+        testID="settingsLanguageButton"
+      >
+        <ListItemIcon
+          iconName={
+            experimentalP2pUpgrade ? "check-box" : "check-box-outline-blank"
+          }
+        />
+        <ListItemText
+          primary={<FormattedMessage {...m.p2pUpgrades} />}
+          secondary={<FormattedMessage {...m.p2pUpgradesDesc} />}
+        ></ListItemText>
+      </ListItem>
+    </List>
+  );
+};
+
+export default Experiments;

--- a/src/frontend/screens/Settings/Experiments.js
+++ b/src/frontend/screens/Settings/Experiments.js
@@ -23,21 +23,22 @@ const m = defineMessages({
 });
 
 const Experiments = () => {
-  const [{ experimentalP2pUpgrade }, setSettings] = React.useContext(
-    SettingsContext
-  );
+  const [{ experiments }, setSettings] = React.useContext(SettingsContext);
 
   return (
     <List testID="settingsList">
       <ListItem
         onPress={() =>
-          setSettings("experimentalP2pUpgrade", !experimentalP2pUpgrade)
+          setSettings("experiments", {
+            ...experiments,
+            p2pUpgrade: !experiments.p2pUpgrade,
+          })
         }
         testID="settingsLanguageButton"
       >
         <ListItemIcon
           iconName={
-            experimentalP2pUpgrade ? "check-box" : "check-box-outline-blank"
+            experiments.p2pUpgrade ? "check-box" : "check-box-outline-blank"
           }
         />
         <ListItemText

--- a/src/frontend/screens/Settings/Settings.js
+++ b/src/frontend/screens/Settings/Settings.js
@@ -84,6 +84,16 @@ const m = defineMessages({
     defaultMessage: "Choose how coordinates are displayed",
     description: "Description of the 'Coordinate Format' page",
   },
+  experiments: {
+    id: "screens.Settings.experiments",
+    defaultMessage: "Experiments",
+    description: "Experimental features",
+  },
+  experimentsDesc: {
+    id: "screens.Settings.experimentsDesc",
+    defaultMessage: "Turn on experimental new features",
+    description: "Description of the 'Experiment' page",
+  },
 });
 
 const Settings = () => {

--- a/src/frontend/screens/Settings/Settings.js
+++ b/src/frontend/screens/Settings/Settings.js
@@ -150,10 +150,10 @@ const Settings = () => {
         ></ListItemText>
       </ListItem>
       <ListItem
-        onPress={() => navigate("Experimental")}
+        onPress={() => navigate("Experiments")}
         testID="settingsExperimentButton"
       >
-        <ListItemIcon iconName="info" />
+        <ListItemIcon iconName="flag" />
         <ListItemText
           primary={<FormattedMessage {...m.experiments} />}
           secondary={<FormattedMessage {...m.experimentsDesc} />}

--- a/src/frontend/screens/Settings/Settings.js
+++ b/src/frontend/screens/Settings/Settings.js
@@ -2,13 +2,8 @@
 import React from "react";
 // import { Picker as OriginalPicker } from "@react-native-community/picker";
 import { FormattedMessage, defineMessages } from "react-intl";
-import { useNavigation, useFocusEffect } from "react-navigation-hooks";
-import RNFS from "react-native-fs";
-import Share from "react-native-share";
-import { version as APP_VERSION } from "../../../../package.json";
+import { useNavigation } from "react-navigation-hooks";
 
-import ApkInstaller from "../../lib/ApkInstaller";
-import AppInfo from "../../lib/AppInfo";
 import HeaderTitle from "../../sharedComponents/HeaderTitle";
 import {
   List,
@@ -16,7 +11,6 @@ import {
   ListItemText,
   ListItemIcon,
 } from "../../sharedComponents/List";
-import { StyleSheet, View, ActivityIndicator } from "react-native";
 
 const m = defineMessages({
   settingsTitle: {
@@ -98,14 +92,6 @@ const m = defineMessages({
 
 const Settings = () => {
   const { navigate } = useNavigation();
-  const didNavigateAway = React.useRef(false);
-
-  useFocusEffect(
-    React.useCallback(() => {
-      didNavigateAway.current = false;
-      return () => (didNavigateAway.current = true);
-    }, [])
-  );
 
   return (
     <List testID="settingsList">

--- a/src/frontend/screens/Settings/Settings.js
+++ b/src/frontend/screens/Settings/Settings.js
@@ -88,61 +88,7 @@ const m = defineMessages({
 
 const Settings = () => {
   const { navigate } = useNavigation();
-  const [status, setStatus] = React.useState("idle");
   const didNavigateAway = React.useRef(false);
-
-  const shareApk = React.useCallback(async () => {
-    const tmpDir = RNFS.DocumentDirectoryPath + "/installer";
-    const apkName = `Mapeo-v${APP_VERSION}.apk`;
-    const tmpApkPath = `${tmpDir}/${apkName}`;
-    setStatus("loading");
-    try {
-      // The apk cannot be shared with other apps from the sourceDir folder, so
-      // we need to create a copy in a place that can be shared. We delete the
-      // copy afterwards
-      await RNFS.mkdir(tmpDir);
-      await RNFS.copyFile(AppInfo.sourceDir, tmpApkPath);
-      if (!didNavigateAway.current) {
-        await Share.open({
-          url: "file://" + tmpApkPath,
-          type: "application/vnd.android.package-archive",
-          failOnCancel: false,
-        });
-      }
-    } catch (e) {
-      console.error("Error sharing APK", e);
-    } finally {
-      await RNFS.unlink(tmpDir);
-      setStatus("idle");
-    }
-  }, []);
-
-  const installApk = React.useCallback(async () => {
-    const tmpDir = RNFS.DocumentDirectoryPath + "/installer";
-    const apkName = `Mapeo-v${APP_VERSION}.apk`;
-    const tmpApkPath = `${tmpDir}/${apkName}`;
-    setStatus("loading");
-    try {
-      await RNFS.mkdir(tmpDir);
-      await RNFS.copyFile(AppInfo.sourceDir, tmpApkPath);
-      if (!didNavigateAway.current) {
-        await ApkInstaller.install(tmpApkPath);
-      }
-    } catch (e) {
-      if (e.code !== "E_INSTALL_CANCELLED") {
-        console.error("Error installing APK", e);
-      }
-    } finally {
-      // Need to cleanup on app startup, because the app will reach here as soon
-      // as install launches, so if we cleanup the file will not exist when the
-      // installer tries to install it. We cannot get the result of the install
-      // activity because we launch it as a new task:
-      // https://developer.android.com/reference/android/content/Intent.html#FLAG_ACTIVITY_NEW_TASK
-      // If we don't launch it as a new task, the install will fail as the app
-      // itself updates and quits the child install activity
-      setStatus("idle");
-    }
-  }, []);
 
   useFocusEffect(
     React.useCallback(() => {
@@ -193,32 +139,14 @@ const Settings = () => {
           secondary={<FormattedMessage {...m.aboutMapeoDesc} />}
         ></ListItemText>
       </ListItem>
-      <ListItem onPress={shareApk}>
-        <ListItemIcon iconName="get-app" />
-        <ListItemText
-          primary={<FormattedMessage {...m.appShare} />}
-          secondary={<FormattedMessage {...m.appShareDesc} />}
-        ></ListItemText>
-      </ListItem>
-      <ListItem onPress={shareApk}>
-        <ListItemIcon iconName="get-app" />
-        <ListItemText
-          primary={<FormattedMessage {...m.appShare} />}
-          secondary={<FormattedMessage {...m.appShareDesc} />}
-        ></ListItemText>
-      </ListItem>
-      <ListItem onPress={installApk}>
-        <ListItemIcon iconName="update" />
-        <ListItemText
-          primary={<FormattedMessage {...m.appInstall} />}
-          secondary={<FormattedMessage {...m.appInstallDesc} />}
-        ></ListItemText>
-      </ListItem>
-      <ListItem>
+      <ListItem
+        onPress={() => navigate("Experimental")}
+        testID="settingsExperimentButton"
+      >
         <ListItemIcon iconName="info" />
         <ListItemText
-          primary="Mapeo Version"
-          secondary={`${APP_VERSION}`}
+          primary={<FormattedMessage {...m.experiments} />}
+          secondary={<FormattedMessage {...m.experimentsDesc} />}
         ></ListItemText>
       </ListItem>
     </List>

--- a/src/frontend/screens/SyncModal/SyncView.js
+++ b/src/frontend/screens/SyncModal/SyncView.js
@@ -393,7 +393,12 @@ const SyncView = ({
     {ssid ? (
       <>
         <WifiBar onPress={onWifiPress} ssid={ssid} deviceName={deviceName} />
-        <UpgradeBar upgradeInfo={upgradeInfo} onInstallPress={onInstallPress} />
+        {upgradeInfo && (
+          <UpgradeBar
+            upgradeInfo={upgradeInfo}
+            onInstallPress={onInstallPress}
+          />
+        )}
         {peers.length ? (
           <PeerList peers={peers} onSyncPress={onSyncPress} />
         ) : (

--- a/src/frontend/screens/SyncModal/index.js
+++ b/src/frontend/screens/SyncModal/index.js
@@ -90,7 +90,7 @@ const SyncModal = ({ navigation }: Props) => {
     if (!backendState.server || !experimentalP2pUpgrade) return;
     const rState = getFrontendStateFromUpgradeState(backendState, peers);
     setUpgradeInfo(rState);
-  }, [peers, backendState, fakeTrigger]);
+  }, [peers, backendState, fakeTrigger, experimentalP2pUpgrade]);
 
   // Backend state tracking effect. Interfaces with Node process for state &
   // control.
@@ -140,7 +140,7 @@ const SyncModal = ({ navigation }: Props) => {
         rnBridge.channel.post("p2p-upgrade::stop-services");
       }
     };
-  }, []);
+  }, [experimentalP2pUpgrade]);
   // ----------------------------------------------------------------------
 
   React.useEffect(() => {

--- a/src/frontend/screens/SyncModal/index.js
+++ b/src/frontend/screens/SyncModal/index.js
@@ -64,7 +64,7 @@ const deviceName: string = "Android " + getUniqueId().slice(0, 4).toUpperCase();
 
 const SyncModal = ({ navigation }: Props) => {
   const [, reload] = useAllObservations();
-  const [{ experimentalP2pUpgrade }] = React.useContext(SettingsContext);
+  const [{ experiments: p2pUpgrade }] = React.useContext(SettingsContext);
 
   const [
     {
@@ -87,10 +87,10 @@ const SyncModal = ({ navigation }: Props) => {
   // ----------------------------------------------------------------------
   // Backend State + Peers => Frontend render effect
   React.useEffect(() => {
-    if (!backendState.server || !experimentalP2pUpgrade) return;
+    if (!backendState.server || !p2pUpgrade) return;
     const rState = getFrontendStateFromUpgradeState(backendState, peers);
     setUpgradeInfo(rState);
-  }, [peers, backendState, fakeTrigger, experimentalP2pUpgrade]);
+  }, [peers, backendState, fakeTrigger, p2pUpgrade]);
 
   // Backend state tracking effect. Interfaces with Node process for state &
   // control.
@@ -123,7 +123,7 @@ const SyncModal = ({ navigation }: Props) => {
       rnBridge.channel.post("p2p-upgrade::get-state");
       rnBridge.channel.post("p2p-upgrade::start-services");
     }
-    if (!experimentalP2pUpgrade) setUpgradeInfo(null);
+    if (!p2pUpgrade) setUpgradeInfo(null);
     else {
       log("startup", upgradeInfo);
       rnBridge.channel.addListener("p2p-upgrades-backend-ready", onReady);
@@ -132,7 +132,7 @@ const SyncModal = ({ navigation }: Props) => {
     }
 
     return () => {
-      if (experimentalP2pUpgrade) {
+      if (p2pUpgrade) {
         log("cleanup!");
         if (iv) clearInterval(iv);
         rnBridge.channel.removeListener("p2p-upgrade::state", onState);
@@ -140,7 +140,7 @@ const SyncModal = ({ navigation }: Props) => {
         rnBridge.channel.post("p2p-upgrade::stop-services");
       }
     };
-  }, [experimentalP2pUpgrade]);
+  }, [p2pUpgrade]);
   // ----------------------------------------------------------------------
 
   React.useEffect(() => {


### PR DESCRIPTION
Solves #549 

- [x] Cleanup old UI on settings page
- [x] Create "Experiments" page and add route
- [x] Create SelectMultiple component based on `src/screens/ObservationDetails/SelectMultiple.js`
- [x] Update settingsContext state on select change
- [x] Update logic to only start and show p2p-upgrades when it's enabled