### PR TITLE
chore: Fix intermittently failing e2e test

### DIFF
--- a/e2e/firstTest.spec.js
+++ b/e2e/firstTest.spec.js
@@ -1,6 +1,7 @@
 /* eslint-env detox/detox, jest/globals */
 
 const { byId, byText } = require("./matcher");
+const delay = require("delay");
 
 // Make it easier to change where the settings screen is later
 const navigateToSettings = async () => {
@@ -62,6 +63,8 @@ describe("Mapeo", () => {
       await byId("observationListItem:0").tap();
       await byId("editButton").tap();
       await byId("observationDescriptionField").typeText("Test description");
+      // This test fails intermittently without a delay here
+      await delay(200);
       // Closes keyboard
       await device.pressBack();
       // Cancels edit

--- a/package-lock.json
+++ b/package-lock.json
@@ -13822,6 +13822,12 @@
         }
       }
     },
+    "delay": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-5.0.0.tgz",
+      "integrity": "sha512-ReEBKkIfe4ya47wlPYf/gu5ib6yUG0/Aez0JQZQz94kiWtRQvZIQbTiehsnwHvLSWJnQdhVeqYue7Id1dKr0qw==",
+      "dev": true
+    },
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
     "babel-plugin-react-intl-auto": "^3.3.0",
     "babel-plugin-react-native-web": "^0.12.2",
     "conventional-changelog-cli": "^2.0.34",
+    "delay": "^5.0.0",
     "detox": "^17.4.10",
     "eslint": "^7.6.0",
     "eslint-config-prettier": "^6.11.0",


### PR DESCRIPTION
The e2e test for cancelled observation edits has been failing intermittently (about 25% of the time) and I think it is due to a race condition - the observation is being cancelled before the edited text is saved. Hopefully this small await will fix this.