### PR TITLE
[DRAFT] Error handling

### DIFF
--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -164,6 +164,7 @@ class Search extends EventEmitter {
 
       this.discovery.destroy(err => {
         if (err) {
+          // Ignorable error
           this.setState(UpgradeState.Search.Error, err);
           searchLog("..stopped, with error:", err);
         } else {
@@ -236,6 +237,11 @@ class Download extends EventEmitter {
           option.version,
           option.hash,
           err => {
+            // Warning: worth showing a dialog box
+            // THOUGHT: it would be nice if there was a way for this component to, like, reset itself?
+            //   some options:
+            //     1. set to state Error, like we do here, then, after a timeout, set to Idle again
+            //     2. expose a 'reset()' function that the frontend can manually call that resets the entire upgrade system
             if (err) this.setState(UpgradeState.Download.Error, err);
             else this.setState(UpgradeState.Download.Downloaded, null);
           }
@@ -276,6 +282,8 @@ class Check extends EventEmitter {
 
     checkLog("checking for an upgrade..");
     this.storage.getAvailableUpgrades((err, options) => {
+      // Seriously fatal error, if upgrade storage ever becomes corrupted
+      // in the future this might warrant a way for the frontend to purge storage to reset it?
       if (err) return this.setState(UpgradeState.Check.Error, err);
       options = options.filter(o => this.isUpgradeCandidate(o));
       if (options.length > 0) {

--- a/src/backend/lib/upgrade-manager.js
+++ b/src/backend/lib/upgrade-manager.js
@@ -1,3 +1,9 @@
+// DEFINITIONS of errors, for the context of this diff
+//
+// Fatal: upgrade feature won't work anymore
+// Warning: worth showing a dialog to inform the user
+// Ignorable: not even worth telling the user able
+
 const UpgradeStorage = require("./upgrade-storage");
 const UpgradeServer = require("./upgrade-server");
 const UpgradeDownload = require("./upgrade-download");
@@ -108,6 +114,8 @@ class UpgradeManager {
     const result = validate(this.state);
     if (result) {
       const msg = result.join(",");
+      // Validation error: this indicates an internal error that should never happen.
+      // If it does: definitely a fatal error.
       this.emit("p2p-upgrade::error", { message: msg });
     } else {
       this.sanitizeState();

--- a/src/backend/lib/upgrade-server.js
+++ b/src/backend/lib/upgrade-server.js
@@ -83,6 +83,7 @@ class UpgradeServer extends EventEmitter {
     this.stateLock.writeLock(release => {
       const self = this;
       function done(err) {
+        // Ignorable. this only fires if discovery.destroy() errors, which is fine
         if (err) self.setState(UpgradeState.Server.Error, err);
         release();
         if (cb) cb(err);


### PR DESCRIPTION
Hey @gmaclennan, this is a discussion / notes PR (not to be merged!) for the various places errors rise up out of the p2p upgrades backend code. See the diff for notes!

```
// DEFINITIONS of errors, for the context of this diff
//
// Fatal: upgrade feature won't work anymore
// Warning: worth showing a dialog to inform the user
// Ignorable: not even worth telling the user about
```