### PR TITLE
Support downloading subsequent newer versions of the app

### DIFF
--- a/src/backend/lib/constants.js
+++ b/src/backend/lib/constants.js
@@ -11,7 +11,6 @@ const UpgradeState = {
   Download: {
     Idle: "IDLE",
     Downloading: "DOWNLOADING",
-    Downloaded: "DOWNLOADED",
     Error: "ERROR",
   },
 

--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -220,7 +220,7 @@ class Download extends EventEmitter {
 
   reset() {
     if (this.state !== UpgradeState.Download.Downloaded) return;
-    this.setState(UpgradeState.Download.Idle);
+    this.setState(UpgradeState.Download.Idle, null);
   }
 
   download(option) {
@@ -258,7 +258,6 @@ class Download extends EventEmitter {
         pump(res, progress, ws, err => {
           if (err) downloadLog("download pipeline error", err);
           else downloadLog("download pipeline ended ok");
-          this.setState(UpgradeState.Download.Idle, null);
         });
       })
       .once("error", err => {

--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -48,7 +48,6 @@ class UpgradeDownloader extends EventEmitter {
       // Check for a new version if the downloader gets set back to Idle.
       if (state === UpgradeState.Download.Idle) {
         this._check.check();
-        this._search.reset();
       }
     });
     this._check.on("state", (state, context) => {
@@ -184,12 +183,6 @@ class Search extends EventEmitter {
 
   // Resets the state 'context' of this component, wiping all accumulated
   // upgrade candidates.
-  reset() {
-    if (this.state !== UpgradeState.Search.Searching) return;
-    this.stop();
-    this.start();
-  }
-
   // UpgradeOption -> Bool
   isUpgradeCandidate(upgrade) {
     if (upgrade.arch.indexOf(this.storage.getLocalArch()) === -1) return false;
@@ -217,10 +210,6 @@ class Download extends EventEmitter {
     this.state = state;
     this.context = context;
     this.emit("state", state, context);
-  }
-
-  reset() {
-    this.setState(UpgradeState.Download.Idle, null);
   }
 
   download(option) {

--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -275,12 +275,13 @@ class Check extends EventEmitter {
   }
 
   check() {
-    if (this.state !== UpgradeState.Check.NotAvailable) return;
-
     checkLog("checking for an upgrade..");
     this.storage.getAvailableUpgrades((err, options) => {
       if (err) return this.setState(UpgradeState.Check.Error, err);
-      options = options.filter(o => this.isUpgradeCandidate(o));
+      options = options
+        .filter(o => this.isUpgradeCandidate(o))
+        .sort(upgradeCmp)
+        .reverse();
       if (options.length > 0) {
         checkLog("..found a viable upgrade", options[0]);
         this.setState(UpgradeState.Check.Available, {
@@ -301,6 +302,12 @@ class Check extends EventEmitter {
       return false;
     return true;
   }
+}
+
+function upgradeCmp(a, b) {
+  const av = a.version;
+  const bv = b.version;
+  return semver.compare(av, bv);
 }
 
 module.exports = UpgradeDownloader;

--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -49,6 +49,7 @@ class UpgradeDownloader extends EventEmitter {
       if (state === UpgradeState.Download.Downloaded) {
         this._check.check();
         this._download.reset();
+        this._search.reset();
       }
     });
     this._check.on("state", (state, context) => {
@@ -180,6 +181,12 @@ class Search extends EventEmitter {
     this.state = state;
     this.context = context;
     this.emit("state", state, context);
+  }
+
+  reset() {
+    if (this.state !== UpgradeState.Search.Searching) return;
+    this.stop();
+    this.start();
   }
 
   // UpgradeOption -> Bool

--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -48,6 +48,7 @@ class UpgradeDownloader extends EventEmitter {
       // Check for a new version once the download has finished
       if (state === UpgradeState.Download.Downloaded) {
         this._check.check();
+        this._download.reset();
       }
     });
     this._check.on("state", (state, context) => {
@@ -210,8 +211,14 @@ class Download extends EventEmitter {
     this.emit("state", state, context);
   }
 
+  reset() {
+    if (this.state !== UpgradeState.Download.Downloaded) return;
+    this.setState(UpgradeState.Download.Idle);
+  }
+
   download(option) {
-    if (this.state !== UpgradeState.Download.Idle) return;
+    if (this.state !== UpgradeState.Download.Idle) return false;
+
     this.setState(UpgradeState.Download.Downloading, {
       sofar: 0,
       total: option.size,
@@ -251,6 +258,8 @@ class Download extends EventEmitter {
         downloadLog("http error", err);
         this.setState(UpgradeState.Download.Idle, null);
       });
+
+    return true;
   }
 }
 

--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -45,10 +45,9 @@ class UpgradeDownloader extends EventEmitter {
       this.state.download = { state, context };
       this.emit("state", this.state);
 
-      // Check for a new version once the download has finished
-      if (state === UpgradeState.Download.Downloaded) {
+      // Check for a new version if the downloader gets set back to Idle.
+      if (state === UpgradeState.Download.Idle) {
         this._check.check();
-        this._download.reset();
         this._search.reset();
       }
     });
@@ -183,6 +182,8 @@ class Search extends EventEmitter {
     this.emit("state", state, context);
   }
 
+  // Resets the state 'context' of this component, wiping all accumulated
+  // upgrade candidates.
   reset() {
     if (this.state !== UpgradeState.Search.Searching) return;
     this.stop();
@@ -219,7 +220,6 @@ class Download extends EventEmitter {
   }
 
   reset() {
-    if (this.state !== UpgradeState.Download.Downloaded) return;
     this.setState(UpgradeState.Download.Idle, null);
   }
 
@@ -251,7 +251,7 @@ class Download extends EventEmitter {
           option.hash,
           err => {
             if (err) this.setState(UpgradeState.Download.Error, err);
-            else this.setState(UpgradeState.Download.Downloaded, null);
+            else this.setState(UpgradeState.Download.Idle, null);
           }
         );
         downloadLog("starting download of upgrade", option);

--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -262,7 +262,6 @@ class Download extends EventEmitter {
       })
       .once("error", err => {
         downloadLog("http error", err);
-        this.setState(UpgradeState.Download.Idle, null);
       });
 
     return true;

--- a/src/backend/lib/upgrade-manager.js
+++ b/src/backend/lib/upgrade-manager.js
@@ -122,25 +122,28 @@ class UpgradeManager {
   }
 
   onCheckForUpgrades() {
+    if (!this.upgradeSearchTimeout) return;
+
+    // Reset timer.
+    this.upgradeSearchTimeout = setTimeout(
+      this.onCheckForUpgrades.bind(this),
+      7000
+    );
+
+    // Pick the newest upgrade, if available
     log("checking for upgrade options..");
-    if (this.upgradeSearchTimeout) {
-      // Pick the newest upgrade, if available
-      this.upgradeOptions.sort(upgradeCmp);
+    this.upgradeOptions.sort(upgradeCmp);
 
-      if (!this.upgradeOptions.length) {
-        log("..none found");
-        this.upgradeSearchTimeout = setTimeout(
-          this.onCheckForUpgrades.bind(this),
-          7000
-        );
-        return;
-      }
+    if (!this.upgradeOptions.length) {
+      log("..none found");
+      return;
+    }
 
-      // Download
-      const target = this.upgradeOptions[this.upgradeOptions.length - 1];
+    // Download
+    const target = this.upgradeOptions[this.upgradeOptions.length - 1];
+    const res = this.downloader.download(target);
+    if (res) {
       log("..found an upgrade & starting download:", target);
-      this.downloader.download(target);
-      this.upgradeSearchTimeout = null;
     }
   }
 }

--- a/src/backend/lib/upgrade-manager.js
+++ b/src/backend/lib/upgrade-manager.js
@@ -47,8 +47,10 @@ class UpgradeManager {
     });
 
     this.downloader.on("state", state => {
-      if (state.search.context && state.search.context.upgrades) {
+      if (state.search.state === "SEARCHING") {
         this.upgradeOptions = state.search.context.upgrades;
+      } else if (state.search.state === "Idle") {
+        this.upgradeOptions = [];
       }
     });
 

--- a/src/backend/lib/upgrade-manager.js
+++ b/src/backend/lib/upgrade-manager.js
@@ -124,7 +124,7 @@ class UpgradeManager {
     log("checking for upgrade options..");
     if (this.upgradeSearchTimeout) {
       // Pick the newest upgrade, if available
-      this.upgradeOptions.sort(semver.compare);
+      this.upgradeOptions.sort(upgradeCmp);
 
       if (!this.upgradeOptions.length) {
         log("..none found");
@@ -142,6 +142,12 @@ class UpgradeManager {
       this.upgradeSearchTimeout = null;
     }
   }
+}
+
+function upgradeCmp(a, b) {
+  const av = a.version;
+  const bv = b.version;
+  return semver.compare(av, bv);
 }
 
 module.exports = UpgradeManager;

--- a/src/backend/lib/upgrade-manager.js
+++ b/src/backend/lib/upgrade-manager.js
@@ -34,11 +34,6 @@ class UpgradeManager {
         this.onCheckForUpgrades.bind(this),
         7000
       );
-      this.downloader.on("state", state => {
-        if (state.search.context && state.search.context.upgrades) {
-          this.upgradeOptions = state.search.context.upgrades;
-        }
-      });
     });
 
     this.addListener("p2p-upgrade::stop-services", () => {
@@ -48,6 +43,12 @@ class UpgradeManager {
 
       if (this.upgradeSearchTimeout) {
         clearTimeout(this.upgradeSearchTimeout);
+      }
+    });
+
+    this.downloader.on("state", state => {
+      if (state.search.context && state.search.context.upgrades) {
+        this.upgradeOptions = state.search.context.upgrades;
       }
     });
 

--- a/src/backend/lib/validate-upgrade-state.js
+++ b/src/backend/lib/validate-upgrade-state.js
@@ -33,7 +33,7 @@ module.exports = (function () {
         context: Any,
       },
       download: {
-        state: Enum("IDLE", "DOWNLOADING", "DOWNLOADED", "ERROR"),
+        state: Enum("IDLE", "DOWNLOADING", "ERROR"),
         context: Any,
       },
       check: {
@@ -78,15 +78,13 @@ module.exports = (function () {
         },
       },
       download: {
-        state: Enum("IDLE", "DOWNLOADING", "DOWNLOADED", "ERROR"),
+        state: Enum("IDLE", "DOWNLOADING", "ERROR"),
         context: c => {
           switch (downloadState) {
             case UpgradeState.Download.Idle:
               return c === null ? undefined : "context must be null";
             case UpgradeState.Download.Downloading:
               return downloadInfo({ c });
-            case UpgradeState.Download.Downloaded:
-              return c === null ? undefined : "context must be null";
             case UpgradeState.Download.Error:
               return "object" === typeof c && c.message
                 ? undefined

--- a/src/backend/test/upgrade-download.js
+++ b/src/backend/test/upgrade-download.js
@@ -143,6 +143,7 @@ test("can find + download + check an upgrade", t => {
 
       function awaitFoundUpgrade(cb) {
         download.start();
+
         download.once("state", state => {
           t.equals(state.search.context.upgrades.length, 1, "upgrade found ok");
           const option = state.search.context.upgrades[0];
@@ -161,7 +162,7 @@ test("can find + download + check an upgrade", t => {
           if (state.download.state === "DOWNLOADING") {
             lastProgress = state.download.context;
           }
-          if (state.download.state === "DOWNLOADED") {
+          if (state.download.state === "IDLE") {
             t.equals(lastProgress.sofar, 10, "final sofar progress ok");
             t.equals(lastProgress.total, 10, "final total progress ok");
             done = true;
@@ -252,7 +253,7 @@ test("REGRESSION: a local upgrade equal to app version is not shown", t => {
           if (state.download.state === "DOWNLOADING") {
             lastProgress = state.download.context;
           }
-          if (state.download.state === "DOWNLOADED") {
+          if (state.download.state === "IDLE") {
             t.equals(lastProgress.sofar, 10);
             t.equals(lastProgress.total, 10);
             done = true;
@@ -332,14 +333,16 @@ test("candidate replaced if peer with an upgrade goes down + another appears", t
               awaitFoundUpgrade((err, options2) => {
                 clearTimeout(ix);
                 t.error(err, "found 2nd upgrade candidate ok");
-                t.equals(options2.length, 2);
+                t.equals(options2.length, 2, "# of upgrades ok");
                 t.equals(
                   options2[1].hash,
-                  "3209efeebdbaa5b3faab4df9312d03831092ce71b497235953b7252e78651111"
+                  "3209efeebdbaa5b3faab4df9312d03831092ce71b497235953b7252e78651111",
+                  "hash 1 ok"
                 );
                 t.equals(
                   options2[0].hash,
-                  "78ad74cecb99d1023206bf2f7d9b11b28767fbb9369daa0afa5e4d062c7ce041"
+                  "78ad74cecb99d1023206bf2f7d9b11b28767fbb9369daa0afa5e4d062c7ce041",
+                  "hash 2 ok"
                 );
                 cleanup();
                 download2.stop();

--- a/src/backend/test/upgrade-manager.js
+++ b/src/backend/test/upgrade-manager.js
@@ -146,7 +146,7 @@ test("integration: can find + download + check an upgrade", t => {
           if (state.downloader.download.state === "DOWNLOADING") {
             lastProgress = state.downloader.download.context;
           }
-          if (state.downloader.download.state === "DOWNLOADED") {
+          if (state.downloader.download.state === "IDLE") {
             t.equals(lastProgress.sofar, 10);
             t.equals(lastProgress.total, 10);
             done = true;

--- a/src/frontend/screens/SyncModal/index.js
+++ b/src/frontend/screens/SyncModal/index.js
@@ -293,14 +293,6 @@ function getFrontendStateFromUpgradeState(state, peers) {
     return { state: UpgradeState.WaitingForSync, context: null };
   }
 
-  // Upgrade available + not waiting for syncs to finish.
-  if (state.downloader.check.state === BackendUpgradeState.Check.Available) {
-    return {
-      state: UpgradeState.ReadyToUpgrade,
-      context: state.downloader.check.context,
-    };
-  }
-
   // Upgrade is downloading.
   if (
     state.downloader.download.state === BackendUpgradeState.Download.Downloading
@@ -309,6 +301,14 @@ function getFrontendStateFromUpgradeState(state, peers) {
     return {
       state: UpgradeState.Downloading,
       context: { progress: progress.sofar / progress.total },
+    };
+  }
+
+  // Upgrade available + not waiting for syncs to finish.
+  if (state.downloader.check.state === BackendUpgradeState.Check.Available) {
+    return {
+      state: UpgradeState.ReadyToUpgrade,
+      context: state.downloader.check.context,
     };
   }
 

--- a/src/frontend/screens/SyncModal/index.js
+++ b/src/frontend/screens/SyncModal/index.js
@@ -277,14 +277,6 @@ function getFrontendStateFromUpgradeState(state, peers) {
     };
   }
 
-  // Edge case I've (kira) seen once that shouldn't happen.
-  if (state.downloader.search.state === BackendUpgradeState.Search.Idle) {
-    return {
-      state: UpgradeState.GenericError,
-      context: "Search did not initialize correctly.",
-    };
-  }
-
   // Upgrade available + waiting for syncs to finish.
   if (
     state.downloader.check.state === BackendUpgradeState.Check.Available &&
@@ -314,8 +306,9 @@ function getFrontendStateFromUpgradeState(state, peers) {
 
   // Subsystem has been searching for upgrades for < 14 seconds.
   if (
-    state.downloader.search.state === BackendUpgradeState.Search.Searching &&
-    Date.now() - state.downloader.search.context.startTime < 14 * 1000
+    state.downloader.search.state === BackendUpgradeState.Search.Idle ||
+    (state.downloader.search.state === BackendUpgradeState.Search.Searching &&
+      Date.now() - state.downloader.search.context.startTime < 14 * 1000)
   ) {
     return { state: UpgradeState.Searching, context: null };
   }


### PR DESCRIPTION
Fixes #540.

This branch adds support for downloading multiple upgrades in a row. Previously the upgrade state machine would download at most **one** upgrade before locking itself into a state where it would download no more unless the app was restarted.