### PR TITLE
Enable Typescript on backend via JSDoc

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -3751,6 +3751,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
+      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "dev": true
+    },
     "uint64be": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/uint64be/-/uint64be-2.0.2.tgz",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -5,6 +5,9 @@
   "engines": {
     "node": "^10.16.0"
   },
+  "scripts": {
+    "type": "tsc"
+  },
   "description": "Mapeo Core running on nodejs-mobile",
   "main": "main.js",
   "author": "Digital Democracy",
@@ -32,6 +35,7 @@
   },
   "devDependencies": {
     "node-gyp-build": "^4.2.1",
-    "noderify": "^5.0.0"
+    "noderify": "^5.0.0",
+    "typescript": "^4.2.4"
   }
 }

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "compilerOptions": {
+    "target": "es2019",
+    "lib": ["es2020"],
+    "resolveJsonModule": true,
     "allowJs": true,
     "checkJs": false,
     "noEmit": true,

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -5,6 +5,6 @@
     "noEmit": true,
     "typeRoots": ["types", "node_modules/@types"]
   },
-  "include": ["*.js", "test/**/*"],
+  "include": ["**/*.js"],
   "exclude": ["node_modules/"]
 }

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "es2019",
     "lib": ["es2020"],
     "resolveJsonModule": true,
+    "moduleResolution": "node",
     "allowJs": true,
     "checkJs": false,
     "noEmit": true,

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "noEmit": true,
+    "typeRoots": ["types", "node_modules/@types"]
+  },
+  "include": ["*.js", "test/**/*"],
+  "exclude": ["node_modules/"]
+}

--- a/src/backend/tsconfig.json
+++ b/src/backend/tsconfig.json
@@ -6,5 +6,5 @@
     "typeRoots": ["types", "node_modules/@types"]
   },
   "include": ["**/*.js"],
-  "exclude": ["node_modules/"]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
As proposed in https://github.com/digidem/mapeo-desktop/issues/467