### PR TITLE
fix: Fix ApkInstaller for Android <7 (SDK version <24)

### DIFF
--- a/android/app/src/main/java/com/mapeo/ApkInstallerModule.java
+++ b/android/app/src/main/java/com/mapeo/ApkInstallerModule.java
@@ -1,10 +1,12 @@
 package com.mapeo;
 
 import android.content.Intent;
+import android.content.ActivityNotFoundException;
 import android.app.Activity;
 import android.net.Uri;
 import android.os.Build;
 import androidx.core.content.FileProvider;
+import android.util.Log;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.BaseActivityEventListener;
@@ -21,8 +23,10 @@ import java.io.File;
 public class ApkInstallerModule extends ReactContextBaseJavaModule {
 
   private final ReactApplicationContext reactContext;
+  private static final String TAG = "ApkInstaller";
   private static final int INSTALL_REQUEST = 3033;
   private static final String E_ACTIVITY_DOES_NOT_EXIST = "E_ACTIVITY_DOES_NOT_EXIST";
+  private static final String E_FILE_DOES_NOT_EXIST = "E_FILE_DOES_NOT_EXIST";
   private static final String E_INSTALL_CANCELLED = "E_INSTALL_CANCELLED";
   private static final String E_INSTALL_FAILED = "E_INSTALL_FAILED";
 
@@ -39,6 +43,7 @@ public class ApkInstallerModule extends ReactContextBaseJavaModule {
           } else if (resultCode == Activity.RESULT_OK) {
             mPickerPromise.resolve(null);
           } else {
+            Log.e(TAG, "Install failed, result code: " + resultCode);
             mPickerPromise.reject(E_INSTALL_FAILED, "Install failed");
           }
           mPickerPromise = null;
@@ -68,32 +73,54 @@ public class ApkInstallerModule extends ReactContextBaseJavaModule {
       return;
     }
 
+    File apkFile = new File(filePath);
+    if (!apkFile.exists()) {
+        Log.e(TAG, "installApk: file does not exist '" + filePath + "'");
+        promise.reject(E_FILE_DOES_NOT_EXIST, "Apk file does not exist");
+        return;
+    }
+
     // Store the promise to resolve/reject when installer activity completes
     mPickerPromise = promise;
 
     Intent intent = new Intent();
-    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-    intent.setAction(Intent.ACTION_VIEW);
-    File apkFile = new File(filePath);
-    Uri apkUri;
 
-    try {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-        intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-        String authority = reactContext.getPackageName() + ".provider";
-        apkUri = FileProvider.getUriForFile(reactContext, authority, apkFile);
-      } else {
-        apkUri = Uri.fromFile(apkFile);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      // API24 and up has a package installer that can handle FileProvider content:// URIs
+      String authority = reactContext.getPackageName() + ".provider";
+      Uri apkUri;
+      try {
+        apkUri = FileProvider.getUriForFile(getReactApplicationContext(), authority, apkFile);
+      } catch (Exception e) {
+        Log.e(TAG, "installApk exception with authority name '" + authority + "'", e);
+        mPickerPromise.reject(e);
+        mPickerPromise = null;
+        return;
       }
-      // This does not actually do anything - it should allow installs without
-      // "unknown sources" checked, but apparently it only works for system apps
-      // installed by an OEM https://issuetracker.google.com/issues/36963283
-      intent.putExtra(Intent.EXTRA_NOT_UNKNOWN_SOURCE, true);
+      intent.setAction(Intent.ACTION_INSTALL_PACKAGE);
+      intent.setDataAndType(apkUri, "application/vnd.android.package-archive");
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
       intent.putExtra(Intent.EXTRA_RETURN_RESULT, true);
       intent.putExtra(Intent.EXTRA_INSTALLER_PACKAGE_NAME, reactContext.getPackageName());
-      intent.setDataAndType(apkUri, "application/vnd.android.package-archive");
+    } else {
+      // Old APIs do not handle content:// URIs, so use an old file:// style
+      // The apk file and any parent folders need to be world-accessible for the
+      // package installer to be able to access them.
+      apkFile.setReadable(true, false);
+      // WARNING: This assumes that this is in a folder one-level deep within
+      // the internal storage files dir (getFilesDir()).
+      apkFile.getParentFile().setExecutable(true, false);
+      Uri apkUri = Uri.fromFile(apkFile);
+      intent.setAction(Intent.ACTION_INSTALL_PACKAGE);
+      intent.setData(apkUri);
+      intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+      intent.putExtra(Intent.EXTRA_RETURN_RESULT, true);
+    }
+    try {
       currentActivity.startActivityForResult(intent, INSTALL_REQUEST);
-    } catch (Exception e) {
+    } catch (ActivityNotFoundException e) {
+      Log.e(TAG, "ActivityNotFoundException", e);
       mPickerPromise.reject(e);
       mPickerPromise = null;
     }


### PR DESCRIPTION
Fixes #582 

It turns out that for Android <7, the APK and any parent folders need to have their file permissions set be world-readable. E.g. we store the APK in `[INTERNAL_FILES_DIR]/installer/myApk.apk`. To be able to install this, `myApk.apk` needs to be world-readable and the `installer` folder needs to be world-executable.

We _could_ set these permissions when creating the `installer` folder, but since these permissions are only needed on Android <7 I think it's better to leave the folder with more restrictive permissions, and set the permissions in the Java code which only runs for Android <7.

Ideally the Java code that sets permissions would set all parent folders up to `[INTERNAL_FILES_DIR]` to be world-executable, but my Java knowledge it not good enough, so for now it assumes the APK is in a folder one-level deep, e.g. it only sets permissions on the parent folder.

@luandro can you test this on your phone and see if it now works as expected?
