### PR TITLE
fix: Throttle upload/download progress events to 400ms

### DIFF
--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -5,7 +5,6 @@ const EventEmitter = require("events").EventEmitter;
 const dns = require("dns-discovery");
 const RWLock = require("rwlock");
 const pump = require("pump");
-const through = require("through2");
 const searchLog = require("debug")("p2p-upgrades:search");
 const downloadLog = require("debug")("p2p-upgrades:download");
 const checkLog = require("debug")("p2p-upgrades:check");
@@ -226,7 +225,6 @@ class Download extends EventEmitter {
     http
       .get({ hostname: option.host, port: option.port, path: url }, res => {
         const filename = option.hash;
-        let sofar = 0;
         const progress = progressStream({
           length: option.size,
           time: 100, // ms between each progress event

--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -14,7 +14,7 @@ const progressStream = require("progress-stream");
 const { DISCOVERY_KEY, UpgradeState } = require("./constants");
 
 // How frequently to emit progress events (in ms)
-const PROGRESS_THROTTLE = 400; // milliseconds
+const PROGRESS_THROTTLE_MS = 400; // milliseconds
 
 // Manager object responsible for coordinating the Search, Download, and Check
 // subcomponents.
@@ -230,7 +230,7 @@ class Download extends EventEmitter {
         const filename = option.hash;
         const progress = progressStream({
           length: option.size,
-          time: PROGRESS_THROTTLE, // ms between each progress event
+          time: PROGRESS_THROTTLE_MS, // ms between each progress event
         });
         progress.on("progress", ({ transferred: sofar, length: total }) => {
           this.setState(UpgradeState.Download.Downloading, { sofar, total });

--- a/src/backend/lib/upgrade-download.js
+++ b/src/backend/lib/upgrade-download.js
@@ -13,6 +13,9 @@ const progressStream = require("progress-stream");
 
 const { DISCOVERY_KEY, UpgradeState } = require("./constants");
 
+// How frequently to emit progress events (in ms)
+const PROGRESS_THROTTLE = 400; // milliseconds
+
 // Manager object responsible for coordinating the Search, Download, and Check
 // subcomponents.
 class UpgradeDownloader extends EventEmitter {
@@ -227,7 +230,7 @@ class Download extends EventEmitter {
         const filename = option.hash;
         const progress = progressStream({
           length: option.size,
-          time: 100, // ms between each progress event
+          time: PROGRESS_THROTTLE, // ms between each progress event
         });
         progress.on("progress", ({ transferred: sofar, length: total }) => {
           this.setState(UpgradeState.Download.Downloading, { sofar, total });

--- a/src/backend/lib/upgrade-server.js
+++ b/src/backend/lib/upgrade-server.js
@@ -17,7 +17,7 @@ type UploadInfo = {
 */
 
 // How frequently to emit progress events (in ms)
-const PROGRESS_THROTTLE = 400; // milliseconds
+const PROGRESS_THROTTLE_MS = 400; // milliseconds
 
 class UpgradeServer extends EventEmitter {
   constructor(storage, port) {
@@ -234,7 +234,7 @@ class UpgradeServer extends EventEmitter {
 
         const tracker = progressStream({
           length: option.size,
-          time: PROGRESS_THROTTLE, // ms between each progress event
+          time: PROGRESS_THROTTLE_MS, // ms between each progress event
         });
         tracker.on("progress", ({ transferred }) => {
           upload.sofar = transferred;

--- a/src/backend/lib/upgrade-server.js
+++ b/src/backend/lib/upgrade-server.js
@@ -16,6 +16,9 @@ type UploadInfo = {
 }
 */
 
+// How frequently to emit progress events (in ms)
+const PROGRESS_THROTTLE = 400; // milliseconds
+
 class UpgradeServer extends EventEmitter {
   constructor(storage, port) {
     super();
@@ -231,7 +234,7 @@ class UpgradeServer extends EventEmitter {
 
         const tracker = progressStream({
           length: option.size,
-          time: 100, // ms between each progress event
+          time: PROGRESS_THROTTLE, // ms between each progress event
         });
         tracker.on("progress", ({ transferred }) => {
           upload.sofar = transferred;

--- a/src/backend/lib/upgrade-server.js
+++ b/src/backend/lib/upgrade-server.js
@@ -2,7 +2,6 @@ const pump = require("pump");
 const discovery = require("dns-discovery");
 const EventEmitter = require("events").EventEmitter;
 const RWLock = require("rwlock");
-const through = require("through2");
 const http = require("http");
 const { DISCOVERY_KEY, UpgradeState } = require("./constants");
 const log = require("debug")("p2p-upgrades:server");
@@ -50,7 +49,6 @@ class UpgradeServer extends EventEmitter {
   // Callback<Void> -> Void
   share(cb) {
     this.stateLock.writeLock(release => {
-      const self = this;
       function done() {
         release();
         if (cb) cb();

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -3942,6 +3942,31 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
+    "progress-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/progress-stream/-/progress-stream-2.0.0.tgz",
+      "integrity": "sha1-+sY6Cz0R3qy7CWmrzJOyFLzhntU=",
+      "requires": {
+        "speedometer": "~1.0.0",
+        "through2": "~2.0.3"
+      },
+      "dependencies": {
+        "speedometer": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/speedometer/-/speedometer-1.0.0.tgz",
+          "integrity": "sha1-zWccsGdSwivKM3Di8zREC+T8YuI="
+        },
+        "through2": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+          "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+          "requires": {
+            "readable-stream": "~2.3.6",
+            "xtend": "~4.0.1"
+          }
+        }
+      }
+    },
     "protocol-buffers-encodings": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/protocol-buffers-encodings/-/protocol-buffers-encodings-1.1.1.tgz",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -27,6 +27,7 @@
     "mapeo-default-settings": "^3.4.0",
     "mapeo-server": "^17.1.0",
     "mkdirp": "^1.0.4",
+    "progress-stream": "^2.0.0",
     "pump": "^3.0.0",
     "random-access-file": "^2.1.5",
     "read-only-stream": "^2.0.0",


### PR DESCRIPTION
Fixes #529 using the [`progress-stream`](https://www.npmjs.com/package/progress-stream) module for progress events to only emit progress every 100ms.
