### PR TITLE
chore: Minify and shrink native resources with ProGuard

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -116,7 +116,7 @@ def enableSeparateBuildPerCPUArchitecture = false
 /**
  * Run Proguard to shrink the Java bytecode in release builds.
  */
-def enableProguardInReleaseBuilds = false
+def enableProguardInReleaseBuilds = true
 
 /**
  * The preferred build flavor of JavaScriptCore.
@@ -250,6 +250,7 @@ android {
     buildTypes {
         release {
             minifyEnabled enableProguardInReleaseBuilds
+            shrinkResources true
             proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
             signingConfig signingConfigs.release
             ndk {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -264,6 +264,8 @@ android {
             ndk {
                 abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
             }
+            // Detox-specific additions to pro-guard
+            proguardFile "${rootProject.projectDir}/../node_modules/detox/android/detox/proguard-rules-app.pro"
         }
         debug {
             // We need to set this to null so that we can override it for variants


### PR DESCRIPTION
Moved from #606. The Detox e2e tests are currently breaking when Proguard is enabled. This needs further investigation see https://github.com/wix/Detox/blob/ac6cb24321acc3df1b09bbfea450b20a353cfa09/docs/Introduction.Android.md#7-proguard-minification-obfuscation
