### PR TITLE
(Front) Direction arrow testing

### DIFF
--- a/src/frontend/sharedComponents/MapView.js
+++ b/src/frontend/sharedComponents/MapView.js
@@ -356,6 +356,7 @@ class MapView extends React.Component<Props, State> {
               <MapboxGL.UserLocation
                 visible={isFocused}
                 minDisplacement={MIN_DISPLACEMENT}
+                showsUserHeadingIndicator={true}
               />
             ) : null}
           </MapboxGL.MapView>

--- a/src/frontend/sharedComponents/MapView.js
+++ b/src/frontend/sharedComponents/MapView.js
@@ -83,7 +83,7 @@ function mapObservationsToFeatures(
 // Min distance in meters the user moves before the map will re-render (saves
 // lots of map renders when the user is standing still, which uses up battery
 // life)
-const MIN_DISPLACEMENT = 1;
+const MIN_DISPLACEMENT = 15;
 
 class ObservationMapLayer extends React.PureComponent<{
   onPress: Function,
@@ -355,7 +355,7 @@ class MapView extends React.Component<Props, State> {
             {locationServicesEnabled ? (
               <MapboxGL.UserLocation
                 visible={isFocused}
-                minDisplacement={MIN_DISPLACEMENT}
+                minDisplacement={1}
                 showsUserHeadingIndicator={true}
               />
             ) : null}

--- a/src/frontend/sharedComponents/MapView.js
+++ b/src/frontend/sharedComponents/MapView.js
@@ -83,7 +83,7 @@ function mapObservationsToFeatures(
 // Min distance in meters the user moves before the map will re-render (saves
 // lots of map renders when the user is standing still, which uses up battery
 // life)
-const MIN_DISPLACEMENT = 15;
+const MIN_DISPLACEMENT = 1;
 
 class ObservationMapLayer extends React.PureComponent<{
   onPress: Function,


### PR DESCRIPTION
Currently need to determine a better way to show the user what direction they are pointing. 

# Battery Usage

### Without directional arrow:
<img width="978" alt="image" src="https://user-images.githubusercontent.com/67773827/142781670-5dc3df4d-e439-4588-9bef-069baad027f8.png">

### With directional arrow:
<img width="971" alt="image" src="https://user-images.githubusercontent.com/67773827/142781701-8d771ea9-920a-423e-9e54-6e7564b8b2ba.png">

As you can see from the image above, the battery usage went from 0.07% to 0.22%, about a 200% increase in battery usage.



