### PR TITLE
Add experimental onboarding flag in settings context

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9762,6 +9762,12 @@
         "@types/node": "*"
       }
     },
+    "@types/lodash": {
+      "version": "4.14.172",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.172.tgz",
+      "integrity": "sha512-/BHF5HAx3em7/KkzVKm3LrsD6HZAXuXO1AJZQ3cRRBZj4oHZDviWPYu0aEplAqDFNHZPW6d3G7KN+ONcCCC7pw==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -31474,6 +31480,7 @@
         "chalk": "^2.4.2",
         "cross-spawn": "^6.0.5",
         "find-yarn-workspace-root": "^1.2.1",
+        "fs-extra": "^7.0.1",
         "is-ci": "^2.0.0",
         "klaw-sync": "^6.0.0",
         "minimist": "^1.2.0",
@@ -31483,6 +31490,16 @@
         "tmp": "^0.0.33"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+          "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "jsonfile": "^4.0.0",
+            "universalify": "^0.1.0"
+          }
+        },
         "minimist": {
           "version": "1.2.5",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@turf/random": "^6.0.2",
     "@types/debug": "^4.1.6",
     "@types/jest": "^26.0.24",
+    "@types/lodash": "^4.14.172",
     "@types/react": "^16.3.1",
     "@types/react-dom": "^16.3.1",
     "@types/react-native": "^0.63.2",


### PR DESCRIPTION
Based on Gregor's [comment](https://github.com/digidem/mapeo-mobile/pull/656#issuecomment-890990672) RE: integrating onboarding flows as a feature flag. Entirely possible that I've misinterpreted the comment with this implementation cc @gmaclennan 

Notes:
- adds an `onboarding` field to the `experiments` field in the SettingsContext