### PR TITLE
Move onboarding screens into their own namespace

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "start": "react-native start",
-    "start-otf": "FEATURE_ONBOARDING=true npm start",
+    "start-otf": "FEATURE_ONBOARDING=true npm start -- --reset-cache",
     "start-icca": "RN_SRC_EXT=icca.js react-native start",
     "android": "npm run build:backend && npm run android-no-backend-rebuild",
     "android-no-backend-rebuild": "react-native run-android --variant=appDebug --appIdSuffix=debug",

--- a/src/frontend/NavigationStacks/OnboardingStack.tsx
+++ b/src/frontend/NavigationStacks/OnboardingStack.tsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { createStackNavigator } from "react-navigation-stack";
-import { CreateOrJoinScreen } from "../screens/CreateOrJoinScreen";
-import JoinProjectQrScreen from "../screens/JoinProjectQrScreen";
-import SendJoinRequestScreen from "../screens/SendJoinRequestScreen";
+import {
+  CreateOrJoinScreen,
+  JoinProjectQrScreen,
+  SendJoinRequestScreen,
+} from "../screens/Onboarding/";
 import CustomHeaderLeft from "../sharedComponents/CustomHeaderLeft";
 
 export const OnboardingStack = createStackNavigator(

--- a/src/frontend/screens/Onboarding/CreateOrJoinScreen.tsx
+++ b/src/frontend/screens/Onboarding/CreateOrJoinScreen.tsx
@@ -1,12 +1,13 @@
 import React from "react";
 import { View, Text, StyleSheet, Image } from "react-native";
-import Button from "../sharedComponents/Button";
 import { useNavigation } from "react-navigation-hooks";
 import { defineMessages, FormattedMessage } from "react-intl";
 import {
   NavigationStackOptions,
   NavigationStackScreenComponent,
 } from "react-navigation-stack";
+
+import Button from "../../sharedComponents/Button";
 
 const m = defineMessages({
   joinProject: {
@@ -29,7 +30,7 @@ export const CreateOrJoinScreen: NavigationStackScreenComponent = () => {
   return (
     <View style={styles.container}>
       <View style={styles.logoContainer}>
-        <Image source={require("../images/icon_mapeo_pin.png")} />
+        <Image source={require("../../images/icon_mapeo_pin.png")} />
       </View>
 
       <Text style={styles.title}>Mapeo</Text>

--- a/src/frontend/screens/Onboarding/JoinProjectQrScreen.tsx
+++ b/src/frontend/screens/Onboarding/JoinProjectQrScreen.tsx
@@ -4,17 +4,14 @@ import { useNavigation } from "react-navigation-hooks";
 import { NavigationStackScreenComponent } from "react-navigation-stack";
 import { FormattedMessage, defineMessages } from "react-intl";
 import QRCode from "react-native-qrcode-svg";
-import { getUniqueId } from "react-native-device-info";
-import OpenSettings from "react-native-android-open-settings";
 
-import useWifiStatus from "../hooks/useWifiStatus";
-import { MEDIUM_BLUE, WHITE } from "../lib/styles";
-import { BackIcon } from "../sharedComponents/icons";
-import Button from "../sharedComponents/Button";
-import HeaderTitle from "../sharedComponents/HeaderTitle";
-import IconButton from "../sharedComponents/IconButton";
-import Text from "../sharedComponents/Text";
-import WifiBar from "../sharedComponents/WifiBar";
+import { MEDIUM_BLUE, WHITE } from "../../lib/styles";
+import { BackIcon } from "../../sharedComponents/icons";
+import Button from "../../sharedComponents/Button";
+import HeaderTitle from "../../sharedComponents/HeaderTitle";
+import IconButton from "../../sharedComponents/IconButton";
+import Text from "../../sharedComponents/Text";
+import { WithWifiBar } from "./WithWifiBar";
 
 const m = defineMessages({
   title: {
@@ -35,19 +32,11 @@ const m = defineMessages({
   },
 });
 
-const JoinProjectQrScreen: NavigationStackScreenComponent = () => {
+export const JoinProjectQrScreen: NavigationStackScreenComponent = () => {
   const navigation = useNavigation();
-  const { ssid } = useWifiStatus();
-
-  const deviceName = "Android " + getUniqueId().slice(0, 4).toUpperCase();
 
   return (
-    <View style={styles.pageContainer}>
-      <WifiBar
-        deviceName={deviceName}
-        ssid={ssid}
-        onPress={() => OpenSettings.wifiSettings()}
-      />
+    <WithWifiBar>
       <View style={styles.container}>
         <View>
           <View style={styles.qrCodeContainer}>
@@ -72,7 +61,7 @@ const JoinProjectQrScreen: NavigationStackScreenComponent = () => {
           </Text>
         </Button>
       </View>
-    </View>
+    </WithWifiBar>
   );
 };
 
@@ -94,9 +83,6 @@ JoinProjectQrScreen.navigationOptions = () => ({
 });
 
 const styles = StyleSheet.create({
-  pageContainer: {
-    flex: 1,
-  },
   container: {
     alignItems: "center",
     justifyContent: "space-between",
@@ -127,5 +113,3 @@ const styles = StyleSheet.create({
     textDecorationLine: "underline",
   },
 });
-
-export default JoinProjectQrScreen;

--- a/src/frontend/screens/Onboarding/SendJoinRequestScreen.tsx
+++ b/src/frontend/screens/Onboarding/SendJoinRequestScreen.tsx
@@ -1,21 +1,19 @@
 import * as React from "react";
 import { Share, StyleSheet, View } from "react-native";
 import { FormattedMessage, defineMessages } from "react-intl";
-import { getUniqueId } from "react-native-device-info";
 import {
   NavigationStackScreenComponent,
   TransitionPresets,
 } from "react-navigation-stack";
 
-import useWifiStatus from "../hooks/useWifiStatus";
-import { MEDIUM_BLUE, WHITE } from "../lib/styles";
-import HeaderTitle from "../sharedComponents/HeaderTitle";
-import { BackIcon } from "../sharedComponents/icons";
-import Button from "../sharedComponents/Button";
-import IconButton from "../sharedComponents/IconButton";
-import WifiBar from "../sharedComponents/WifiBar";
-import Text from "../sharedComponents/Text";
-import { URI_PREFIX } from "../constants";
+import { MEDIUM_BLUE, WHITE } from "../../lib/styles";
+import HeaderTitle from "../../sharedComponents/HeaderTitle";
+import { BackIcon } from "../../sharedComponents/icons";
+import Button from "../../sharedComponents/Button";
+import IconButton from "../../sharedComponents/IconButton";
+import Text from "../../sharedComponents/Text";
+import { URI_PREFIX } from "../../constants";
+import { WithWifiBar } from "./WithWifiBar";
 
 const m = defineMessages({
   title: {
@@ -36,11 +34,7 @@ const m = defineMessages({
   },
 });
 
-const SendJoinRequestScreen: NavigationStackScreenComponent = () => {
-  const { ssid } = useWifiStatus();
-
-  const deviceName = "Android " + getUniqueId().slice(0, 4).toUpperCase();
-
+export const SendJoinRequestScreen: NavigationStackScreenComponent = () => {
   // TOOD: Need to properly generate
   const verificationCode = Math.random().toString().slice(-5);
 
@@ -48,8 +42,7 @@ const SendJoinRequestScreen: NavigationStackScreenComponent = () => {
   const shareLink = `${URI_PREFIX}main/onboarding?code=${verificationCode}`;
 
   return (
-    <View style={styles.pageContainer}>
-      <WifiBar deviceName={deviceName} ssid={ssid} />
+    <WithWifiBar>
       <View style={styles.container}>
         <View>
           <Text style={styles.verificationCodeTitle}>
@@ -68,7 +61,7 @@ const SendJoinRequestScreen: NavigationStackScreenComponent = () => {
           </Text>
         </Button>
       </View>
-    </View>
+    </WithWifiBar>
   );
 };
 
@@ -91,9 +84,6 @@ SendJoinRequestScreen.navigationOptions = () => ({
 });
 
 const styles = StyleSheet.create({
-  pageContainer: {
-    flex: 1,
-  },
   container: {
     alignItems: "center",
     justifyContent: "space-between",
@@ -119,5 +109,3 @@ const styles = StyleSheet.create({
     paddingHorizontal: 40,
   },
 });
-
-export default SendJoinRequestScreen;

--- a/src/frontend/screens/Onboarding/WithWifiBar.tsx
+++ b/src/frontend/screens/Onboarding/WithWifiBar.tsx
@@ -1,0 +1,29 @@
+import * as React from "react";
+import { View, StyleSheet } from "react-native";
+import { getUniqueId } from "react-native-device-info";
+import OpenSettings from "react-native-android-open-settings";
+
+import useWifiStatus from "../../hooks/useWifiStatus";
+import WifiBar from "../../sharedComponents/WifiBar";
+
+export const WithWifiBar = ({ children }: React.PropsWithChildren<{}>) => {
+  const { ssid } = useWifiStatus();
+  const deviceName = "Android " + getUniqueId().slice(0, 4).toUpperCase();
+
+  return (
+    <View style={styles.container}>
+      <WifiBar
+        deviceName={deviceName}
+        ssid={ssid}
+        onPress={() => OpenSettings.wifiSettings()}
+      />
+      {children}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/frontend/screens/Onboarding/index.ts
+++ b/src/frontend/screens/Onboarding/index.ts
@@ -1,0 +1,3 @@
+export * from "./CreateOrJoinScreen";
+export * from "./JoinProjectQrScreen";
+export * from "./SendJoinRequestScreen";


### PR DESCRIPTION
Notes:
- Moves the onboarding-specific screens into a `/screens/Onboarding/` directory. This will make it easier to consolidate and isolate work for OTF onboarding
- Adds a simple wrapper for screens that include the wifi status bar, since there are quite a few in the onboarding flow
- Fixes npm command for `start-otf`