### PR TITLE
Project config screen

### DIFF
--- a/src/frontend/App.js
+++ b/src/frontend/App.js
@@ -15,7 +15,7 @@ import AppProvider from "./context/AppProvider";
 import bugsnag from "./lib/logger";
 import IS_E2E from "./lib/is-e2e";
 import useUpdateNotifierEffect from "./hooks/useUpdateNotifierEffect";
-import { LeaveProjectScreen } from "./screens/LeaveProject/LeaveProject";
+import { LeaveProjectInitial } from "./screens/LeaveProject/LeaveProjectInitial";
 
 // Turn off warnings about require cycles
 LogBox.ignoreLogs(["Require cycle:"]);

--- a/src/frontend/NavigationStacks/AppStack.tsx
+++ b/src/frontend/NavigationStacks/AppStack.tsx
@@ -22,16 +22,11 @@ import AboutMapeo from "../screens/Settings/AboutMapeo";
 import LanguageSettings from "../screens/Settings/LanguageSettings";
 import CoordinateFormat from "../screens/Settings/CoordinateFormat";
 import HomeHeader from "../sharedComponents/HomeHeader";
-import { LeaveProjectInitial } from "../screens/LeaveProject/LeaveProjectInitial";
-import { LeaveProjectProgress } from "../screens/LeaveProject/LeaveProjectProgess";
-import { LeaveProjectCompleted } from "../screens/LeaveProject/LeaveProjectCompleted";
-
-
-import UnableToLinkScreen from "../screens/UnableToLink";
+import { AlreadyOnProj } from "../screens/AlreadyOnProject";
+import { LeaveProjectScreen } from "../screens/LeaveProject";
+import { AddToProjectScreen } from "../screens/AddToProjectScreen";
+import {UnableToLinkScreen} from "../screens/UnableToLink";
 import { JoinProjectQrScreen } from "../screens/Onboarding";
-import AlreadyOnProj from "../screens/AlreadyOnProject";
-import LeaveProjectScreen from "../screens/LeaveProject";
-import { AddToProjectScreen } from "../screens/AddToProjectScreen"
 const HomeTabs = createBottomTabNavigator(
   {
     Map: MapScreen,

--- a/src/frontend/NavigationStacks/AppStack.tsx
+++ b/src/frontend/NavigationStacks/AppStack.tsx
@@ -25,12 +25,13 @@ import HomeHeader from "../sharedComponents/HomeHeader";
 import { LeaveProjectInitial } from "../screens/LeaveProject/LeaveProjectInitial";
 import { LeaveProjectProgress } from "../screens/LeaveProject/LeaveProjectProgess";
 import { LeaveProjectCompleted } from "../screens/LeaveProject/LeaveProjectCompleted";
-import { AlreadyOnProj } from "../screens/AlreadyOnProject";
-import { AddToProjectScreen } from "../screens/AddToProjectScreen";
+
+
 import UnableToLinkScreen from "../screens/UnableToLink";
 import { JoinProjectQrScreen } from "../screens/Onboarding";
+import AlreadyOnProj from "../screens/AlreadyOnProject";
 import LeaveProjectScreen from "../screens/LeaveProject";
-
+import { AddToProjectScreen } from "../screens/AddToProjectScreen"
 const HomeTabs = createBottomTabNavigator(
   {
     Map: MapScreen,

--- a/src/frontend/NavigationStacks/AppStack.tsx
+++ b/src/frontend/NavigationStacks/AppStack.tsx
@@ -22,13 +22,14 @@ import AboutMapeo from "../screens/Settings/AboutMapeo";
 import LanguageSettings from "../screens/Settings/LanguageSettings";
 import CoordinateFormat from "../screens/Settings/CoordinateFormat";
 import HomeHeader from "../sharedComponents/HomeHeader";
-import { LeaveProjectScreen } from "../screens/LeaveProject/LeaveProject";
+import { LeaveProjectInitial } from "../screens/LeaveProject/LeaveProjectInitial";
 import { LeaveProjectProgress } from "../screens/LeaveProject/LeaveProjectProgess";
 import { LeaveProjectCompleted } from "../screens/LeaveProject/LeaveProjectCompleted";
 import { AlreadyOnProj } from "../screens/AlreadyOnProject";
 import { AddToProjectScreen } from "../screens/AddToProjectScreen";
 import UnableToLinkScreen from "../screens/UnableToLink";
 import { JoinProjectQrScreen } from "../screens/Onboarding";
+import LeaveProjectScreen from "../screens/LeaveProject";
 
 const HomeTabs = createBottomTabNavigator(
   {
@@ -77,8 +78,6 @@ export const AppStack = createStackNavigator(
     ManualGpsScreen: ManualGpsScreen,
     ObservationDetails: ObservationDetails,
     LeaveProjectScreen: LeaveProjectScreen,
-    LeaveProjectProgress: LeaveProjectProgress,
-    LeaveProjectCompleted: LeaveProjectCompleted,
     AlreadyOnProj: AlreadyOnProj,
     AddToProject: AddToProjectScreen,
     UnableToLink: UnableToLinkScreen,

--- a/src/frontend/screens/AlreadyOnProject.tsx
+++ b/src/frontend/screens/AlreadyOnProject.tsx
@@ -45,7 +45,7 @@ const navSettings: NavigationStackOptions = {
   headerShown: false,
 };
 
-const AlreadyOnProj: NavigationStackScreenComponent = () => {
+export const AlreadyOnProj: NavigationStackScreenComponent = () => {
   const [config] = useContext(ConfigContext);
   const { formatMessage: t } = useIntl();
   const nav = useNavigation();
@@ -99,8 +99,6 @@ const AlreadyOnProj: NavigationStackScreenComponent = () => {
 };
 
 AlreadyOnProj.navigationOptions = navSettings;
-
-export default AlreadyOnProj;
 
 const styles = StyleSheet.create({
   screenContainer: {

--- a/src/frontend/screens/AlreadyOnProject.tsx
+++ b/src/frontend/screens/AlreadyOnProject.tsx
@@ -45,7 +45,7 @@ const navSettings: NavigationStackOptions = {
   headerShown: false,
 };
 
-export const AlreadyOnProj: NavigationStackScreenComponent = () => {
+const AlreadyOnProj: NavigationStackScreenComponent = () => {
   const [config] = useContext(ConfigContext);
   const { formatMessage: t } = useIntl();
   const nav = useNavigation();
@@ -76,11 +76,10 @@ export const AlreadyOnProj: NavigationStackScreenComponent = () => {
         <FormattedMessage {...m.leaveInstructions} />
       </Text>
 
-      {/* To Do => navigate to leave project flow when merged with that branch */}
       <Button
         style={[styles.buttons, { backgroundColor: "#FF0000", marginTop: 30 }]}
         onPress={() => {
-          return;
+          nav.navigate("LeaveProjectScreen");
         }}
       >
         {t(m.leaveButton)}
@@ -100,6 +99,8 @@ export const AlreadyOnProj: NavigationStackScreenComponent = () => {
 };
 
 AlreadyOnProj.navigationOptions = navSettings;
+
+export default AlreadyOnProj;
 
 const styles = StyleSheet.create({
   screenContainer: {

--- a/src/frontend/screens/LeaveProject/LeaveProjectCompleted.tsx
+++ b/src/frontend/screens/LeaveProject/LeaveProjectCompleted.tsx
@@ -2,12 +2,7 @@ import React from "react";
 import { defineMessages, FormattedMessage } from "react-intl";
 import { View, Text, StyleSheet, Image } from "react-native";
 import Button from "../../sharedComponents/Button";
-import {
-  NavigationStackOptions,
-  NavigationStackScreenComponent,
-} from "react-navigation-stack";
 import { useNavigation } from "react-navigation-hooks";
-import { ILeaveSharedProp } from ".";
 
 const m = defineMessages({
   projectDeleted: {
@@ -24,15 +19,7 @@ const m = defineMessages({
   },
 });
 
-const navOption: NavigationStackOptions = {
-  headerShown: false,
-};
-
-export const LeaveProjectCompleted = ({
-  screenStateHook,
-}: ILeaveSharedProp) => {
-  const [screen, setScreen] = screenStateHook;
-
+export const LeaveProjectCompleted = () => {
   const nav = useNavigation();
 
   return (

--- a/src/frontend/screens/LeaveProject/LeaveProjectCompleted.tsx
+++ b/src/frontend/screens/LeaveProject/LeaveProjectCompleted.tsx
@@ -7,6 +7,7 @@ import {
   NavigationStackScreenComponent,
 } from "react-navigation-stack";
 import { useNavigation } from "react-navigation-hooks";
+import { ILeaveSharedProp } from ".";
 
 const m = defineMessages({
   projectDeleted: {
@@ -27,7 +28,11 @@ const navOption: NavigationStackOptions = {
   headerShown: false,
 };
 
-export const LeaveProjectCompleted: NavigationStackScreenComponent = () => {
+export const LeaveProjectCompleted = ({
+  screenStateHook,
+}: ILeaveSharedProp) => {
+  const [screen, setScreen] = screenStateHook;
+
   const nav = useNavigation();
 
   return (
@@ -55,8 +60,6 @@ export const LeaveProjectCompleted: NavigationStackScreenComponent = () => {
     </View>
   );
 };
-
-LeaveProjectCompleted.navigationOptions = navOption;
 
 const styles = StyleSheet.create({
   screenContainer: {

--- a/src/frontend/screens/LeaveProject/LeaveProjectInitial.tsx
+++ b/src/frontend/screens/LeaveProject/LeaveProjectInitial.tsx
@@ -10,6 +10,7 @@ import {
   NavigationStackScreenComponent,
 } from "react-navigation-stack";
 import HeaderTitle from "../../sharedComponents/HeaderTitle";
+import { ILeaveSharedProp } from ".";
 
 const m = defineMessage({
   leaveProjectTitle: {
@@ -56,7 +57,8 @@ const navOptions: NavigationStackOptions = {
   ),
 };
 
-export const LeaveProjectScreen: NavigationStackScreenComponent = () => {
+export const LeaveProjectInitial = ({ screenStateHook }: ILeaveSharedProp) => {
+  const [screen, setScreen] = screenStateHook;
   const [confirmDelete, setConfirmDelete] = React.useState(false);
   const [untouched, setUntouched] = useState(true);
   const [config] = useContext(ConfigContext);
@@ -69,8 +71,7 @@ export const LeaveProjectScreen: NavigationStackScreenComponent = () => {
     if (untouched) setUntouched(false);
 
     if (!confirmDelete) return;
-
-    nav.navigate("LeaveProjectProgress");
+    setScreen(screen + 1);
   }
 
   const name = config.metadata.name ? " " + config.metadata.name : "";
@@ -143,8 +144,6 @@ export const LeaveProjectScreen: NavigationStackScreenComponent = () => {
     </View>
   );
 };
-
-LeaveProjectScreen.navigationOptions = navOptions;
 
 const styles = StyleSheet.create({
   screenContainer: {

--- a/src/frontend/screens/LeaveProject/LeaveProjectInitial.tsx
+++ b/src/frontend/screens/LeaveProject/LeaveProjectInitial.tsx
@@ -5,12 +5,7 @@ import CheckBox from "@react-native-community/checkbox";
 import ConfigContext from "../../context/ConfigContext";
 import Button from "../../sharedComponents/Button";
 import { useNavigation } from "react-navigation-hooks";
-import {
-  NavigationStackOptions,
-  NavigationStackScreenComponent,
-} from "react-navigation-stack";
-import HeaderTitle from "../../sharedComponents/HeaderTitle";
-import { ILeaveSharedProp } from ".";
+import { LeaveProjSharedProp } from ".";
 
 const m = defineMessage({
   leaveProjectTitle: {
@@ -49,16 +44,7 @@ const m = defineMessage({
   },
 });
 
-const navOptions: NavigationStackOptions = {
-  headerTitle: () => (
-    <HeaderTitle style={{ color: "#ffffff" }}>
-      <FormattedMessage {...m.headerTitle} />
-    </HeaderTitle>
-  ),
-};
-
-export const LeaveProjectInitial = ({ screenStateHook }: ILeaveSharedProp) => {
-  const [screen, setScreen] = screenStateHook;
+export const LeaveProjectInitial = ({ next }: LeaveProjSharedProp) => {
   const [confirmDelete, setConfirmDelete] = React.useState(false);
   const [untouched, setUntouched] = useState(true);
   const [config] = useContext(ConfigContext);
@@ -71,7 +57,8 @@ export const LeaveProjectInitial = ({ screenStateHook }: ILeaveSharedProp) => {
     if (untouched) setUntouched(false);
 
     if (!confirmDelete) return;
-    setScreen(screen + 1);
+
+    next();
   }
 
   const name = config.metadata.name ? " " + config.metadata.name : "";

--- a/src/frontend/screens/LeaveProject/LeaveProjectProgess.tsx
+++ b/src/frontend/screens/LeaveProject/LeaveProjectProgess.tsx
@@ -5,7 +5,7 @@ import { defineMessages, FormattedMessage } from "react-intl";
 import ConfigContext from "../../context/ConfigContext";
 import { NavigationStackOptions } from "react-navigation-stack";
 import { useState } from "react";
-import { ILeaveSharedProp } from ".";
+import { LeaveProjSharedProp } from ".";
 
 const m = defineMessages({
   leaveProjectTitle: {
@@ -22,15 +22,14 @@ const navOptions: NavigationStackOptions = {
   headerShown: false,
 };
 
-export const LeaveProjectProgress = ({ screenStateHook }: ILeaveSharedProp) => {
-  const [screen, setScreen] = screenStateHook;
+export const LeaveProjectProgress = ({ next }: LeaveProjSharedProp) => {
   const [config] = useContext(ConfigContext);
+
   //To do => When Delete API has been created
   const [progress, setProgress] = useState(0);
-
   setTimeout(() => {
-    setScreen(screen + 1);
-  }, 3000);
+    next();
+  }, 2000);
 
   const name = config.metadata.name || "";
 

--- a/src/frontend/screens/LeaveProject/LeaveProjectProgess.tsx
+++ b/src/frontend/screens/LeaveProject/LeaveProjectProgess.tsx
@@ -3,12 +3,9 @@ import { View, Text, StyleSheet } from "react-native";
 import { Bar } from "react-native-progress";
 import { defineMessages, FormattedMessage } from "react-intl";
 import ConfigContext from "../../context/ConfigContext";
-import {
-  NavigationStackOptions,
-  NavigationStackScreenComponent,
-} from "react-navigation-stack";
+import { NavigationStackOptions } from "react-navigation-stack";
 import { useState } from "react";
-import { useNavigation } from "react-navigation-hooks";
+import { ILeaveSharedProp } from ".";
 
 const m = defineMessages({
   leaveProjectTitle: {
@@ -25,14 +22,14 @@ const navOptions: NavigationStackOptions = {
   headerShown: false,
 };
 
-export const LeaveProjectProgress: NavigationStackScreenComponent = () => {
+export const LeaveProjectProgress = ({ screenStateHook }: ILeaveSharedProp) => {
+  const [screen, setScreen] = screenStateHook;
   const [config] = useContext(ConfigContext);
-  const { navigate } = useNavigation();
   //To do => When Delete API has been created
   const [progress, setProgress] = useState(0);
 
   setTimeout(() => {
-    navigate("LeaveProjectCompleted");
+    setScreen(screen + 1);
   }, 3000);
 
   const name = config.metadata.name || "";
@@ -57,8 +54,6 @@ export const LeaveProjectProgress: NavigationStackScreenComponent = () => {
     </View>
   );
 };
-
-LeaveProjectProgress.navigationOptions = navOptions;
 
 const styles = StyleSheet.create({
   screenContainer: {

--- a/src/frontend/screens/LeaveProject/index.tsx
+++ b/src/frontend/screens/LeaveProject/index.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useState } from "react";
+import { NavigationStackScreenComponent } from "react-navigation-stack";
+import { LeaveProjectCompleted } from "./LeaveProjectCompleted";
+import { LeaveProjectInitial } from "./LeaveProjectInitial";
+import { LeaveProjectProgress } from "./LeaveProjectProgess";
+
+enum ScreenStates {
+  initial,
+  progress,
+  completed,
+}
+
+export interface ILeaveSharedProp {
+  screenStateHook: [
+    ScreenStates,
+    React.Dispatch<React.SetStateAction<ScreenStates>>
+  ];
+}
+
+const LeaveProjectScreen = () => {
+  const { initial, progress, completed } = ScreenStates;
+  const [screen, setScreen] = useState(initial);
+
+  if (screen === initial) {
+    return <LeaveProjectInitial screenStateHook={[screen, setScreen]} />;
+  }
+
+  if (screen === progress) {
+    return <LeaveProjectProgress screenStateHook={[screen, setScreen]} />;
+  }
+
+  return <LeaveProjectCompleted screenStateHook={[screen, setScreen]} />;
+};
+
+export default LeaveProjectScreen;

--- a/src/frontend/screens/LeaveProject/index.tsx
+++ b/src/frontend/screens/LeaveProject/index.tsx
@@ -7,7 +7,6 @@ import { LeaveProjectCompleted } from "./LeaveProjectCompleted";
 import { LeaveProjectInitial } from "./LeaveProjectInitial";
 import { LeaveProjectProgress } from "./LeaveProjectProgess";
 import HeaderTitle from "../../sharedComponents/HeaderTitle";
-import { WHITE } from "../../lib/styles";
 
 const m = defineMessages({
   headerTitle: {
@@ -26,7 +25,7 @@ export interface LeaveProjSharedProp {
   next: () => void;
 }
 
-const LeaveProjectScreen: NavigationStackScreenComponent = () => {
+export const LeaveProjectScreen: NavigationStackScreenComponent = () => {
   const { initial, progress } = ScreenStates;
   const [screen, setScreen] = useState(initial);
 
@@ -47,10 +46,8 @@ const LeaveProjectScreen: NavigationStackScreenComponent = () => {
 
 LeaveProjectScreen.navigationOptions = {
   headerTitle: () => (
-    <HeaderTitle style={{ color: WHITE }}>
+    <HeaderTitle style={{}}>
       <FormattedMessage {...m.headerTitle} />
     </HeaderTitle>
   ),
 };
-
-export default LeaveProjectScreen;

--- a/src/frontend/screens/LeaveProject/index.tsx
+++ b/src/frontend/screens/LeaveProject/index.tsx
@@ -1,9 +1,22 @@
 import React from "react";
 import { useState } from "react";
-import { NavigationStackScreenComponent } from "react-navigation-stack";
+import { defineMessages, FormattedMessage } from "react-intl";
+import {
+  NavigationStackProp,
+  NavigationStackScreenComponent,
+  NavigationStackScreenProps,
+} from "react-navigation-stack";
 import { LeaveProjectCompleted } from "./LeaveProjectCompleted";
 import { LeaveProjectInitial } from "./LeaveProjectInitial";
 import { LeaveProjectProgress } from "./LeaveProjectProgess";
+import HeaderTitle from "../../sharedComponents/HeaderTitle";
+
+const m = defineMessages({
+  headerTitle: {
+    id: "screens.LeaveProject.LeaveProject",
+    defaultMessage: "Leave Project",
+  },
+});
 
 enum ScreenStates {
   initial,
@@ -18,7 +31,11 @@ export interface ILeaveSharedProp {
   ];
 }
 
-const LeaveProjectScreen = () => {
+const LeaveProjectScreen: NavigationStackScreenComponent = ({
+  navigation,
+  screenProps,
+  theme,
+}: NavigationStackScreenProps) => {
   const { initial, progress, completed } = ScreenStates;
   const [screen, setScreen] = useState(initial);
 

--- a/src/frontend/screens/LeaveProject/index.tsx
+++ b/src/frontend/screens/LeaveProject/index.tsx
@@ -1,15 +1,13 @@
 import React from "react";
 import { useState } from "react";
 import { defineMessages, FormattedMessage } from "react-intl";
-import {
-  NavigationStackProp,
-  NavigationStackScreenComponent,
-  NavigationStackScreenProps,
-} from "react-navigation-stack";
+import { NavigationStackScreenComponent } from "react-navigation-stack";
+
 import { LeaveProjectCompleted } from "./LeaveProjectCompleted";
 import { LeaveProjectInitial } from "./LeaveProjectInitial";
 import { LeaveProjectProgress } from "./LeaveProjectProgess";
 import HeaderTitle from "../../sharedComponents/HeaderTitle";
+import { WHITE } from "../../lib/styles";
 
 const m = defineMessages({
   headerTitle: {
@@ -24,30 +22,35 @@ enum ScreenStates {
   completed,
 }
 
-export interface ILeaveSharedProp {
-  screenStateHook: [
-    ScreenStates,
-    React.Dispatch<React.SetStateAction<ScreenStates>>
-  ];
+export interface LeaveProjSharedProp {
+  next: () => void;
 }
 
-const LeaveProjectScreen: NavigationStackScreenComponent = ({
-  navigation,
-  screenProps,
-  theme,
-}: NavigationStackScreenProps) => {
-  const { initial, progress, completed } = ScreenStates;
+const LeaveProjectScreen: NavigationStackScreenComponent = () => {
+  const { initial, progress } = ScreenStates;
   const [screen, setScreen] = useState(initial);
 
+  function nextScreenState() {
+    setScreen(screen => screen + 1);
+  }
+
   if (screen === initial) {
-    return <LeaveProjectInitial screenStateHook={[screen, setScreen]} />;
+    return <LeaveProjectInitial next={nextScreenState} />;
   }
 
   if (screen === progress) {
-    return <LeaveProjectProgress screenStateHook={[screen, setScreen]} />;
+    return <LeaveProjectProgress next={nextScreenState} />;
   }
 
-  return <LeaveProjectCompleted screenStateHook={[screen, setScreen]} />;
+  return <LeaveProjectCompleted />;
+};
+
+LeaveProjectScreen.navigationOptions = {
+  headerTitle: () => (
+    <HeaderTitle style={{ color: WHITE }}>
+      <FormattedMessage {...m.headerTitle} />
+    </HeaderTitle>
+  ),
 };
 
 export default LeaveProjectScreen;

--- a/src/frontend/screens/LeaveProject/index.tsx
+++ b/src/frontend/screens/LeaveProject/index.tsx
@@ -30,7 +30,7 @@ export const LeaveProjectScreen: NavigationStackScreenComponent = () => {
   const [screen, setScreen] = useState(initial);
 
   function nextScreenState() {
-    setScreen(screen => screen + 1);
+    setScreen(previousScreen => previousScreen + 1);
   }
 
   if (screen === initial) {

--- a/src/frontend/screens/Settings/ProjectConfig.tsx
+++ b/src/frontend/screens/Settings/ProjectConfig.tsx
@@ -64,6 +64,11 @@ const m = defineMessages({
     defaultMessage: "Leave Project",
     description: "Button to leave current project",
   },
+  addPerson: {
+    id: "screens.Settings.addPerson",
+    defaultMessage: "Add Person",
+    description: "Button to add person to project",
+  },
 });
 
 const ProjectConfig = () => {
@@ -113,7 +118,7 @@ const ProjectConfig = () => {
           {projectKeySlice ? projectKeySlice + "**********" : "MAPEO"}
         </Text>
 
-        {configName && (
+        {!!configName && (
           <React.Fragment>
             <Text style={[styles.centerText, { marginTop: 10 }]}>
               <FormattedMessage {...m.name} />
@@ -134,29 +139,56 @@ const ProjectConfig = () => {
         disabled={status === "loading" || config.status === "loading"}
         variant="contained"
         onPress={handleImportPress}
-        style={{ marginBottom: 10, marginTop: 40 }}
+        style={[{ marginTop: 40 }, styles.button]}
       >
         {t(m.importConfig) /* Button component expects string children */}
       </Button>
-      <Button
-        disabled={status === "loading" || config.status === "loading"}
-        variant="outlined"
-        onPress={() => navigate("LeaveProjectScreen")}
-      >
-        <View style={styles.LeaveBttn}>
-          <MaterialIcons name="exit-to-app" color="#0066ff" size={18} />
-          <Text
-            style={{
-              color: "#0066ff",
-              fontWeight: "bold",
-              marginLeft: 5,
-              fontSize: 16,
-            }}
+      {process.env.FEATURE_ONBOARDING === "true" && (
+        <React.Fragment>
+          {/* We need to work out permission before we figure out what this button does */}
+          <Button
+            style={styles.button}
+            disabled={status === "loading" || config.status === "loading"}
+            variant="outlined"
+            onPress={() => {}}
           >
-            <FormattedMessage {...m.leaveProject} />
-          </Text>
-        </View>
-      </Button>
+            <View style={styles.LeaveBttn}>
+              <MaterialIcons name="person-add" color="#0066ff" size={18} />
+              <Text
+                style={{
+                  color: "#0066ff",
+                  fontWeight: "bold",
+                  marginLeft: 5,
+                  fontSize: 16,
+                }}
+              >
+                <FormattedMessage {...m.addPerson} />
+              </Text>
+            </View>
+          </Button>
+
+          <Button
+            style={styles.button}
+            disabled={status === "loading" || config.status === "loading"}
+            variant="outlined"
+            onPress={() => navigate("LeaveProjectScreen")}
+          >
+            <View style={styles.LeaveBttn}>
+              <MaterialIcons name="exit-to-app" color="#0066ff" size={18} />
+              <Text
+                style={{
+                  color: "#0066ff",
+                  fontWeight: "bold",
+                  marginLeft: 5,
+                  fontSize: 16,
+                }}
+              >
+                <FormattedMessage {...m.leaveProject} />
+              </Text>
+            </View>
+          </Button>
+        </React.Fragment>
+      )}
     </View>
   );
 };
@@ -212,5 +244,8 @@ const styles = StyleSheet.create({
     color: "#0066ff",
     flexDirection: "row",
     alignItems: "center",
+  },
+  button: {
+    margin: 5,
   },
 });

--- a/src/frontend/screens/Settings/ProjectConfig.tsx
+++ b/src/frontend/screens/Settings/ProjectConfig.tsx
@@ -1,15 +1,14 @@
-// @flow
 import React from "react";
 import { View, StyleSheet, ActivityIndicator, Alert } from "react-native";
 import Text from "../../sharedComponents/Text";
-// import { Picker as OriginalPicker } from "@react-native-community/picker";
 import { FormattedMessage, defineMessages, useIntl } from "react-intl";
 import * as DocumentPicker from "expo-document-picker";
-
+import MaterialIcons from "react-native-vector-icons/MaterialIcons";
 import HeaderTitle from "../../sharedComponents/HeaderTitle";
 import Button from "../../sharedComponents/Button";
 import ConfigContext from "../../context/ConfigContext";
 import type { Status } from "../../types";
+import { useNavigation } from "react-navigation-hooks";
 
 const m = defineMessages({
   configTitle: {
@@ -55,26 +54,25 @@ const m = defineMessages({
     defaultMessage: "Import Config",
     description: "Button to import Mapeo config file",
   },
+  name: {
+    id: "screens.Settings.name",
+    defaultMessage: "Project Name:",
+    description: "Button to import Mapeo config file",
+  },
+  leaveProject: {
+    id: "screens.Settings.leaveProject",
+    defaultMessage: "Leave Project",
+    description: "Button to leave current project",
+  },
 });
-
-// const Picker = ({ label, children, ...props }) => (
-//   <View style={styles.pickerWrapper}>
-//     <Text style={styles.pickerLabel}>{label}</Text>
-//     <View style={styles.picker}>
-//       <OriginalPicker mode="dialog" {...props} prompt={label}>
-//         {children}
-//       </OriginalPicker>
-//     </View>
-//   </View>
-// );
-
-// Picker.Item = OriginalPicker.Item;
 
 const ProjectConfig = () => {
   const { formatMessage: t } = useIntl();
   const [status, setStatus] = React.useState<Status>("idle");
   const [config, { replace: replaceConfig }] = React.useContext(ConfigContext);
   const didError = config.status === "error";
+
+  const { navigate } = useNavigation();
 
   React.useEffect(() => {
     if (!didError) return;
@@ -114,18 +112,50 @@ const ProjectConfig = () => {
         <Text style={[styles.centerText, styles.projectKey]}>
           {projectKeySlice ? projectKeySlice + "**********" : "MAPEO"}
         </Text>
+
+        {configName && (
+          <React.Fragment>
+            <Text style={[styles.centerText, { marginTop: 10 }]}>
+              <FormattedMessage {...m.name} />
+            </Text>
+            <Text style={[styles.centerText, styles.projectKey]}>
+              {configName || ""}
+            </Text>
+          </React.Fragment>
+        )}
         {(status === "loading" || config.status === "loading") && (
           <View style={styles.loadingContainer}>
             <ActivityIndicator size="large" />
           </View>
         )}
       </View>
+
+      <Button
+        disabled={status === "loading" || config.status === "loading"}
+        variant="contained"
+        onPress={handleImportPress}
+        style={{ marginBottom: 10, marginTop: 40 }}
+      >
+        {t(m.importConfig) /* Button component expects string children */}
+      </Button>
       <Button
         disabled={status === "loading" || config.status === "loading"}
         variant="outlined"
-        onPress={handleImportPress}
+        onPress={() => navigate("LeaveProjectScreen")}
       >
-        {t(m.importConfig) /* Button component expects string children */}
+        <View style={styles.LeaveBttn}>
+          <MaterialIcons name="exit-to-app" color="#0066ff" size={18} />
+          <Text
+            style={{
+              color: "#0066ff",
+              fontWeight: "bold",
+              marginLeft: 5,
+              fontSize: 16,
+            }}
+          >
+            <FormattedMessage {...m.leaveProject} />
+          </Text>
+        </View>
       </Button>
     </View>
   );
@@ -133,7 +163,7 @@ const ProjectConfig = () => {
 
 ProjectConfig.navigationOptions = {
   headerTitle: () => (
-    <HeaderTitle>
+    <HeaderTitle style={{}}>
       <FormattedMessage {...m.configTitle} />
     </HeaderTitle>
   ),
@@ -147,20 +177,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 15,
     paddingVertical: 20,
   },
-  // pickerWrapper: {
-  //   marginBottom: 15
-  // },
-  // pickerLabel: {
-  //   marginBottom: 5,
-  //   marginLeft: 2
-  // },
-  // picker: {
-  //   borderWidth: 1,
-  //   borderColor: "#CCCCCC",
-  //   borderStyle: "solid",
-  //   borderRadius: 5,
-  //   paddingLeft: 10
-  // },
   configInfo: {
     marginBottom: 20,
     position: "relative",
@@ -190,6 +206,11 @@ const styles = StyleSheet.create({
     bottom: 0,
     backgroundColor: "rgba(255,255,255,0.9)",
     justifyContent: "center",
+    alignItems: "center",
+  },
+  LeaveBttn: {
+    color: "#0066ff",
+    flexDirection: "row",
     alignItems: "center",
   },
 });

--- a/src/frontend/screens/Settings/ProjectConfig.tsx
+++ b/src/frontend/screens/Settings/ProjectConfig.tsx
@@ -124,7 +124,7 @@ const ProjectConfig = () => {
               <FormattedMessage {...m.name} />
             </Text>
             <Text style={[styles.centerText, styles.projectKey]}>
-              {configName || ""}
+              {configName}
             </Text>
           </React.Fragment>
         )}
@@ -152,7 +152,7 @@ const ProjectConfig = () => {
             variant="outlined"
             onPress={() => {}}
           >
-            <View style={styles.LeaveBttn}>
+            <View style={styles.leaveBttn}>
               <MaterialIcons name="person-add" color="#0066ff" size={18} />
               <Text
                 style={{
@@ -173,7 +173,7 @@ const ProjectConfig = () => {
             variant="outlined"
             onPress={() => navigate("LeaveProjectScreen")}
           >
-            <View style={styles.LeaveBttn}>
+            <View style={styles.leaveBttn}>
               <MaterialIcons name="exit-to-app" color="#0066ff" size={18} />
               <Text
                 style={{
@@ -240,7 +240,7 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     alignItems: "center",
   },
-  LeaveBttn: {
+  leaveBttn: {
     color: "#0066ff",
     flexDirection: "row",
     alignItems: "center",

--- a/src/frontend/screens/UnableToLink.tsx
+++ b/src/frontend/screens/UnableToLink.tsx
@@ -43,7 +43,7 @@ const m = defineMessages({
   },
 });
 
-const UnableToLinkScreen: NavigationStackScreenComponent = () => {
+export const UnableToLinkScreen: NavigationStackScreenComponent = () => {
   const { ssid } = useWifiStatus();
   const { formatMessage: t } = useIntl();
   const { navigate } = useNavigation();
@@ -129,4 +129,3 @@ const styles = StyleSheet.create({
   },
 });
 
-export default UnableToLinkScreen;


### PR DESCRIPTION
# Completed Project config screen

### Hidden under the OTF feature flag
Run script `start-otf` 

Screen is nested in the setting, under "Project Config"

## To Do:
Determine roles and who can "Add a Person"

###  Figma Screen:
[Screen](https://www.figma.com/proto/ZOsM89L0xy0NUOCkuksJgq/OTF-%2B-UXFund?node-id=45997%3A72&scaling=scale-down-width&page-id=45808%3A2&hide-ui=1)