### PR TITLE
Sync screen onboarding

### DIFF
--- a/src/frontend/NavigationStacks/OnboardingStack.tsx
+++ b/src/frontend/NavigationStacks/OnboardingStack.tsx
@@ -5,6 +5,7 @@ import {
   JoinProjectQrScreen,
   SendJoinRequestScreen,
 } from "../screens/Onboarding/";
+import { SyncOnboardingScreen } from "../screens/Onboarding/Sync";
 import CustomHeaderLeft from "../sharedComponents/CustomHeaderLeft";
 
 export const OnboardingStack = createStackNavigator(
@@ -12,9 +13,10 @@ export const OnboardingStack = createStackNavigator(
     CreateOrJoinScreen: CreateOrJoinScreen,
     JoinProjectQr: JoinProjectQrScreen,
     SendJoinRequest: SendJoinRequestScreen,
+    Sync: SyncOnboardingScreen,
   },
   {
-    initialRouteName: "CreateOrJoinScreen",
+    initialRouteName: "Sync",
     // TODO iOS: Dynamically set transition mode to modal for modals
     mode: "card",
     headerMode: "screen",

--- a/src/frontend/NavigationStacks/OnboardingStack.tsx
+++ b/src/frontend/NavigationStacks/OnboardingStack.tsx
@@ -16,7 +16,7 @@ export const OnboardingStack = createStackNavigator(
     Sync: SyncOnboardingScreen,
   },
   {
-    initialRouteName: "Sync",
+    initialRouteName: "CreateOrJoinScreen",
     // TODO iOS: Dynamically set transition mode to modal for modals
     mode: "card",
     headerMode: "screen",

--- a/src/frontend/NavigationStacks/WithModalsStack.tsx
+++ b/src/frontend/NavigationStacks/WithModalsStack.tsx
@@ -11,7 +11,7 @@ const MainStack = createSwitchNavigator(
     Onboarding: OnboardingStack,
   },
   {
-    initialRouteName: "Onboarding",
+    initialRouteName: "App",
   }
 );
 

--- a/src/frontend/NavigationStacks/WithModalsStack.tsx
+++ b/src/frontend/NavigationStacks/WithModalsStack.tsx
@@ -11,7 +11,7 @@ const MainStack = createSwitchNavigator(
     Onboarding: OnboardingStack,
   },
   {
-    initialRouteName: "App",
+    initialRouteName: "Onboarding",
   }
 );
 

--- a/src/frontend/api.js
+++ b/src/frontend/api.js
@@ -23,7 +23,7 @@ import type {
 } from "./context/ObservationsContext";
 import { promiseTimeout } from "./lib/utils";
 import bugsnag from "./lib/logger";
-import STATUS from "./../backend/constants";
+import STATUS from "../backend/constants";
 
 import type { IconSize, ImageSize } from "./types";
 import type { DraftPhoto } from "./context/DraftObservationContext";

--- a/src/frontend/screens/Onboarding/Sync/Complete.tsx
+++ b/src/frontend/screens/Onboarding/Sync/Complete.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { defineMessages, FormattedMessage } from "react-intl";
-import { StyleSheet } from "react-native";
-import { Image, View, Text } from "react-native";
+import { Image, View, Text, StyleSheet } from "react-native";
 import { WHITE } from "../../../lib/styles";
 
 const m = defineMessages({

--- a/src/frontend/screens/Onboarding/Sync/Complete.tsx
+++ b/src/frontend/screens/Onboarding/Sync/Complete.tsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { defineMessages, FormattedMessage } from "react-intl";
+import { StyleSheet } from "react-native";
+import { Image, View, Text } from "react-native";
+import { WHITE } from "../../../lib/styles";
+
+const m = defineMessages({
+  complete: {
+    id: "screens.Onboarding.Sync.Loader.complete",
+    defaultMessage: "Complete!",
+  },
+});
+
+interface SyncCompleteProps {
+  textNode: React.ReactNode;
+}
+
+export const SyncOnboardingComplete = ({ textNode }: SyncCompleteProps) => {
+  return (
+    <View style={styles.container}>
+      <Image
+        style={{ marginBottom: 30 }}
+        source={require("../../../images/completed/checkComplete.png")}
+      />
+
+      <Text style={styles.title}>
+        <FormattedMessage {...m.complete} />
+      </Text>
+
+      {textNode}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  title: {
+    color: WHITE,
+    fontSize: 24,
+    fontWeight: "500",
+    marginBottom: 15,
+  },
+  container: {
+    alignItems: "center",
+  },
+});

--- a/src/frontend/screens/Onboarding/Sync/Loader.tsx
+++ b/src/frontend/screens/Onboarding/Sync/Loader.tsx
@@ -1,0 +1,68 @@
+import React, { useState } from "react";
+import api from "../../../api";
+import { Bar } from "react-native-progress";
+import { View, Text, StyleSheet } from "react-native";
+import { defineMessages, FormattedMessage } from "react-intl";
+import { useMemo } from "react";
+import { DARK_BLUE, MEDIUM_BLUE, WHITE } from "../../../lib/styles";
+
+const m = defineMessages({
+  syncing: {
+    id: "screens.Onboarding.Sync.Loader.syncing",
+    defaultMessage: "Syncing...",
+  },
+  numComplete: {
+    id: "screens.Onboarding.Sync.Loader.numComplete",
+    defaultMessage: "{num}/{total} observations complete",
+  },
+});
+
+interface SyncLoadingProps {
+  textNode: React.ReactNode;
+  progress: number;
+}
+
+export const SyncLoading = ({ textNode, progress }: SyncLoadingProps) => {
+  return (
+    <View style={[styles.screenContainer]}>
+      <Text style={[styles.text, styles.title]}>
+        <FormattedMessage {...m.syncing} />
+      </Text>
+
+      {/* <Text style={[styles.text, styles.subText]}>
+                <FormattedMessage {...m.numComplete} values={{num:completedObservations, total:totalObservations}}/>
+            </Text> */}
+
+      {textNode}
+
+      <Bar
+        style={[{ marginTop: 10 }]}
+        color={DARK_BLUE}
+        unfilledColor={WHITE}
+        progress={progress}
+        height={20}
+        width={null}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  screenContainer: {
+    backgroundColor: MEDIUM_BLUE,
+  },
+  text: {
+    color: WHITE,
+    textAlign: "center",
+    margin: 10,
+  },
+  title: {
+    marginTop: 30,
+    fontSize: 24,
+    fontWeight: "500",
+  },
+  subText: {
+    fontSize: 16,
+    marginBottom: 20,
+  },
+});

--- a/src/frontend/screens/Onboarding/Sync/Loader.tsx
+++ b/src/frontend/screens/Onboarding/Sync/Loader.tsx
@@ -1,9 +1,7 @@
-import React, { useState } from "react";
-import api from "../../../api";
+import React from "react";
 import { Bar } from "react-native-progress";
 import { View, Text, StyleSheet } from "react-native";
 import { defineMessages, FormattedMessage } from "react-intl";
-import { useMemo } from "react";
 import { DARK_BLUE, MEDIUM_BLUE, WHITE } from "../../../lib/styles";
 
 const m = defineMessages({
@@ -28,10 +26,6 @@ export const SyncLoading = ({ textNode, progress }: SyncLoadingProps) => {
       <Text style={[styles.text, styles.title]}>
         <FormattedMessage {...m.syncing} />
       </Text>
-
-      {/* <Text style={[styles.text, styles.subText]}>
-                <FormattedMessage {...m.numComplete} values={{num:completedObservations, total:totalObservations}}/>
-            </Text> */}
 
       {textNode}
 

--- a/src/frontend/screens/Onboarding/Sync/index.tsx
+++ b/src/frontend/screens/Onboarding/Sync/index.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { useEffect } from "react";
 import { useState } from "react";
 import { defineMessages, useIntl, FormattedMessage } from "react-intl";
-import { StyleSheet, View, Text } from "react-native";
+import { StyleSheet, View, Text, Button as Bttn } from "react-native";
 import { NavigationScreenProp } from "react-navigation";
 import { useNavigation } from "react-navigation-hooks";
 import { NavigationStackScreenComponent } from "react-navigation-stack";
@@ -28,38 +28,39 @@ const m = defineMessages({
   },
 });
 
-export const SyncOnboardingScreen: NavigationStackScreenComponent = ({
-  navigation,
-}) => {
+export const SyncOnboardingScreen: NavigationStackScreenComponent = ({}) => {
   //For UI testing purposes
   const [obsCompleted, setObsCompleted] = useState(1);
   const total = 30;
 
-  // useEffect(()=>
-  // {
-  //     const timer = setTimeout(()=>{setObsCompleted(prev => prev+1)}, 100)
-  //     if(obsCompleted === total) return(clearTimeout(timer))
-  // }, [obsCompleted])
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setObsCompleted(prev => prev + 1);
+    }, 100);
+    if (obsCompleted === total) return clearTimeout(timer);
+  }, [obsCompleted]);
 
   //Start of real component
   const { syncing, completed } = SyncScreenStates;
   const [screenState, setScreenState] = useState(syncing);
   const { formatMessage: t } = useIntl();
+  const { navigate } = useNavigation();
 
   const progress = obsCompleted / total;
 
   const completedTextNode = useMemo(() => {
-    return completedMessage(total, total);
+    return progressMessage(total, total);
   }, [total]);
 
   if (progress === 1) {
-    // const completedTimer = setTimeout(()=>{
-    //     clearTimeout(completedTimer)
-    //     if(screenState !== completed)setScreenState(completed)
-    // }, 1000)
+    const completedTimer = setTimeout(() => {
+      clearTimeout(completedTimer);
+      if (screenState !== completed) setScreenState(completed);
+    }, 1000);
   }
 
-  function completedMessage(completed: number, totalObs: number) {
+  //completed message as a JSX component
+  function progressMessage(completed: number, totalObs: number) {
     return (
       <Text style={[styles.text, styles.subText]}>
         <FormattedMessage
@@ -72,20 +73,24 @@ export const SyncOnboardingScreen: NavigationStackScreenComponent = ({
 
   return (
     <View style={styles.screenContainer}>
-      {/*             
-            { screenState === syncing &&
-                <SyncLoading textNode={completedMessage(obsCompleted, total)} progress={progress} />
-            }
+      {screenState === syncing && (
+        <SyncLoading
+          textNode={progressMessage(obsCompleted, total)}
+          progress={progress}
+        />
+      )}
 
-            { screenState === completed &&
-                <SyncOnboardingComplete textNode={completedTextNode} />
-            }
-             */}
+      {screenState === completed && (
+        <SyncOnboardingComplete textNode={completedTextNode} />
+      )}
+
       <Button
-        color="light"
         onPress={() => {
-          setObsCompleted(prev => prev + 1);
+          navigate("App");
         }}
+        variant="outlined"
+        color="light"
+        disabled={screenState === syncing}
       >
         {t(m.startMapping)}
       </Button>

--- a/src/frontend/screens/Onboarding/Sync/index.tsx
+++ b/src/frontend/screens/Onboarding/Sync/index.tsx
@@ -1,0 +1,116 @@
+import React, { useMemo } from "react";
+import { useEffect } from "react";
+import { useState } from "react";
+import { defineMessages, useIntl, FormattedMessage } from "react-intl";
+import { StyleSheet, View, Text } from "react-native";
+import { NavigationScreenProp } from "react-navigation";
+import { useNavigation } from "react-navigation-hooks";
+import { NavigationStackScreenComponent } from "react-navigation-stack";
+import { StackNavigationProp } from "react-navigation-stack/lib/typescript/src/vendor/types";
+import { MEDIUM_BLUE, WHITE } from "../../../lib/styles";
+import Button from "../../../sharedComponents/Button";
+import { SyncOnboardingComplete } from "./Complete";
+import { SyncLoading } from "./Loader";
+
+enum SyncScreenStates {
+  syncing,
+  completed,
+}
+
+const m = defineMessages({
+  startMapping: {
+    id: "screens.Onboarding.Sync.startMapping",
+    defaultMessage: "Start Mapping",
+  },
+  numComplete: {
+    id: "screens.Onboarding.Sync.numComplete",
+    defaultMessage: "{num}/{total} observations complete",
+  },
+});
+
+export const SyncOnboardingScreen: NavigationStackScreenComponent = ({
+  navigation,
+}) => {
+  //For UI testing purposes
+  const [obsCompleted, setObsCompleted] = useState(1);
+  const total = 30;
+
+  // useEffect(()=>
+  // {
+  //     const timer = setTimeout(()=>{setObsCompleted(prev => prev+1)}, 100)
+  //     if(obsCompleted === total) return(clearTimeout(timer))
+  // }, [obsCompleted])
+
+  //Start of real component
+  const { syncing, completed } = SyncScreenStates;
+  const [screenState, setScreenState] = useState(syncing);
+  const { formatMessage: t } = useIntl();
+
+  const progress = obsCompleted / total;
+
+  const completedTextNode = useMemo(() => {
+    return completedMessage(total, total);
+  }, [total]);
+
+  if (progress === 1) {
+    // const completedTimer = setTimeout(()=>{
+    //     clearTimeout(completedTimer)
+    //     if(screenState !== completed)setScreenState(completed)
+    // }, 1000)
+  }
+
+  function completedMessage(completed: number, totalObs: number) {
+    return (
+      <Text style={[styles.text, styles.subText]}>
+        <FormattedMessage
+          {...m.numComplete}
+          values={{ num: completed, total: totalObs }}
+        />
+      </Text>
+    );
+  }
+
+  return (
+    <View style={styles.screenContainer}>
+      {/*             
+            { screenState === syncing &&
+                <SyncLoading textNode={completedMessage(obsCompleted, total)} progress={progress} />
+            }
+
+            { screenState === completed &&
+                <SyncOnboardingComplete textNode={completedTextNode} />
+            }
+             */}
+      <Button
+        color="light"
+        onPress={() => {
+          setObsCompleted(prev => prev + 1);
+        }}
+      >
+        {t(m.startMapping)}
+      </Button>
+    </View>
+  );
+};
+
+SyncOnboardingScreen.navigationOptions = {
+  headerShown: false,
+};
+
+const styles = StyleSheet.create({
+  screenContainer: {
+    flex: 1,
+    backgroundColor: MEDIUM_BLUE,
+    justifyContent: "space-between",
+    padding: "10%",
+  },
+  subText: {
+    fontSize: 16,
+    marginBottom: 20,
+  },
+  text: {
+    color: WHITE,
+    textAlign: "center",
+    margin: 10,
+  },
+});

--- a/src/frontend/screens/Onboarding/Sync/index.tsx
+++ b/src/frontend/screens/Onboarding/Sync/index.tsx
@@ -1,12 +1,8 @@
-import React, { useMemo } from "react";
-import { useEffect } from "react";
-import { useState } from "react";
+import React, { useMemo, useEffect, useState } from "react";
 import { defineMessages, useIntl, FormattedMessage } from "react-intl";
-import { StyleSheet, View, Text, Button as Bttn } from "react-native";
-import { NavigationScreenProp } from "react-navigation";
+import { StyleSheet, View, Text } from "react-native";
 import { useNavigation } from "react-navigation-hooks";
 import { NavigationStackScreenComponent } from "react-navigation-stack";
-import { StackNavigationProp } from "react-navigation-stack/lib/typescript/src/vendor/types";
 import { MEDIUM_BLUE, WHITE } from "../../../lib/styles";
 import Button from "../../../sharedComponents/Button";
 import { SyncOnboardingComplete } from "./Complete";

--- a/src/frontend/screens/ProjectInviteModal/index.tsx
+++ b/src/frontend/screens/ProjectInviteModal/index.tsx
@@ -127,16 +127,6 @@ const ProjectInviteModal: NavigationStackScreenComponent = ({ navigation }) => {
 
   const acceptInvite = () => {
     navigation.navigate("Sync");
-    // Alert.alert(
-    //   "Work in progress",
-    //   "This feature has not been implemented yet",
-    //   [
-    //     {
-    //       text: "Ok",
-    //       onPress: () => closeModal(),
-    //     },
-    //   ]
-    // );
   };
 
   React.useEffect(() => {

--- a/src/frontend/screens/ProjectInviteModal/index.tsx
+++ b/src/frontend/screens/ProjectInviteModal/index.tsx
@@ -126,16 +126,17 @@ const ProjectInviteModal: NavigationStackScreenComponent = ({ navigation }) => {
   };
 
   const acceptInvite = () => {
-    Alert.alert(
-      "Work in progress",
-      "This feature has not been implemented yet",
-      [
-        {
-          text: "Ok",
-          onPress: () => closeModal(),
-        },
-      ]
-    );
+    navigation.navigate("Sync");
+    // Alert.alert(
+    //   "Work in progress",
+    //   "This feature has not been implemented yet",
+    //   [
+    //     {
+    //       text: "Ok",
+    //       onPress: () => closeModal(),
+    //     },
+    //   ]
+    // );
   };
 
   React.useEffect(() => {


### PR DESCRIPTION
# Onboarding Sync Screens
This screen shows the syncing progress, and the completion of the sync. Shows a progress bar that gives the user an indication of how many observations are synced in real time.

## To Do:
* Needs to be linked to API
* Error State

### Figma Screens
[Screen](https://www.figma.com/proto/ZOsM89L0xy0NUOCkuksJgq/OTF-%2B-UXFund?node-id=45829%3A83&scaling=scale-down-width&page-id=45808%3A2&hide-ui=1)

### Syncing Screen Screen Shot:
<img width="302" alt="image" src="https://user-images.githubusercontent.com/67773827/129487877-ae5a8640-4b38-4ae7-b734-20615dc0e989.png">


### Completed Screen Screen Shot:
<img width="303" alt="image" src="https://user-images.githubusercontent.com/67773827/129487858-bb10d2f6-94de-4ed0-b504-2f0e8bdb2dd3.png">
