### PR TITLE
fix: Migrate settings when new settings are added

### DIFF
--- a/src/frontend/context/SettingsContext.js
+++ b/src/frontend/context/SettingsContext.js
@@ -1,10 +1,13 @@
 // @flow
 import * as React from "react";
 import createPersistedState from "../hooks/usePersistedState";
+import merge from "lodash/merge";
 
 // Increment if the shape of settings changes, but try to avoid doing this
-// because it will reset everybody's settings back to the defaults = bad :(
-const STORE_KEY = "@MapeoSettings@2";
+// because it will reset everybody's settings back to the defaults = bad :( It is
+// not necessary to increment this if only adding new properties to the settings
+// state, because we merge the default values into the persisted state.
+const STORE_KEY = "@MapeoSettings@1";
 
 export type CoordinateFormat = "utm" | "dd" | "dms";
 export type ExperimentalP2pUpgrade = boolean;
@@ -46,10 +49,12 @@ export const SettingsProvider = ({ children }: { children: React.Node }) => {
     [setState, state]
   );
 
-  const contextValue = React.useMemo(() => [state, setSettings], [
-    state,
-    setSettings,
-  ]);
+  const contextValue: SettingsContextType = React.useMemo(() => {
+    // If we add any new properties to the settings state, they will be
+    // undefined in a users' persisted state, so we merge in the defaults
+    const mergedState = merge({}, state, DEFAULT_SETTINGS);
+    return [mergedState, setSettings];
+  }, [state, setSettings]);
 
   return (
     <SettingsContext.Provider value={contextValue}>


### PR DESCRIPTION
In https://github.com/digidem/mapeo-mobile/commit/871fce8e09527b2fcdd8df5173b01243a0309cf2#diff-a59c14edfe1f1f35785b6a754daef1fb4c6bb3f1575ebaf90f47328c0693d04d we added the `experiments` property to the settings context, and bumped the version of the persisted settings to `"@MapeoSettings@2"`. This would cause anybody installing the new version of Mapeo to loose their previous settings. This is not desirable behaviour and we can change it since we have not had a release since https://github.com/digidem/mapeo-mobile/commit/871fce8e09527b2fcdd8df5173b01243a0309cf2

This PR merges the default settings object with the users' persisted settings, which ensures that the correct defaults exist for any new settings options that were not persisted from an earlier Mapeo version.
