### PR TITLE
Add connecting step in Add to Project flow

### DIFF
--- a/src/frontend/screens/AddToProjectScreen/ConnectStep.tsx
+++ b/src/frontend/screens/AddToProjectScreen/ConnectStep.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { StyleSheet, View } from "react-native";
+import { FormattedMessage, defineMessages } from "react-intl";
+import Text from "../../sharedComponents/Text";
+
+const m = defineMessages({
+  title: {
+    id: "screens.AddToProjectScreen.ConnectStep.title",
+    defaultMessage: "Connecting to device...",
+  },
+});
+
+export const ConnectStep = () => (
+  <View style={styles.container}>
+    <View>
+      <Text style={[styles.title, styles.centeredText]}>
+        <FormattedMessage {...m.title} />
+      </Text>
+    </View>
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingVertical: 20,
+  },
+  title: {
+    fontSize: 40,
+    fontWeight: "bold",
+  },
+  centeredText: {
+    textAlign: "center",
+  },
+});

--- a/src/frontend/screens/AddToProjectScreen/DeviceFoundStep/index.tsx
+++ b/src/frontend/screens/AddToProjectScreen/DeviceFoundStep/index.tsx
@@ -18,35 +18,32 @@ type Role = "participant" | "coordinator";
 
 const m = defineMessages({
   title: {
-    id: "screens.Onboarding.AddToProjectScreen.DeviceFoundStep.title",
+    id: "screens.AddToProjectScreen.DeviceFoundStep.title",
     defaultMessage: "Device {deviceId} Found",
   },
   participantOptionTitle: {
-    id:
-      "screens.Onboarding.AddToProjectScreen.DeviceFoundStep.participantOptionTitle",
+    id: "screens.AddToProjectScreen.DeviceFoundStep.participantOptionTitle",
     defaultMessage: "This device is a Participant",
   },
   coordinatorOptionTitle: {
-    id:
-      "screens.Onboarding.AddToProjectScreen.DeviceFoundStep.coordinatorOptionTitle",
+    id: "screens.AddToProjectScreen.DeviceFoundStep.coordinatorOptionTitle",
     defaultMessage: "This device is a Coordinator",
   },
   coordinatorOptionDescription: {
     id:
-      "screens.Onboarding.AddToProjectScreen.DeviceFoundStep.coordinatorOptionDescription",
+      "screens.AddToProjectScreen.DeviceFoundStep.coordinatorOptionDescription",
     defaultMessage: "Coordinators can add and remove devices from projects",
   },
   selectValidationError: {
-    id:
-      "screens.Onboarding.AddToProjectScreen.DeviceFoundStep.selectValidationError",
+    id: "screens.AddToProjectScreen.DeviceFoundStep.selectValidationError",
     defaultMessage: "Select a role for the device",
   },
   cancel: {
-    id: "screens.Onboarding.AddToProjectScreen.DeviceFoundStep.cancel",
+    id: "screens.AddToProjectScreen.DeviceFoundStep.cancel",
     defaultMessage: "Cancel",
   },
   inviteDevice: {
-    id: "screens.Onboarding.AddToProjectScreen.inviteDevice",
+    id: "screens.AddToProjectScreen.inviteDevice",
     defaultMessage: "Invite Device",
   },
 });

--- a/src/frontend/screens/AddToProjectScreen/ScanQrCodeStep.tsx
+++ b/src/frontend/screens/AddToProjectScreen/ScanQrCodeStep.tsx
@@ -17,22 +17,19 @@ const reportMountError = (error: CameraMountError) => {
 
 const m = defineMessages({
   title: {
-    id:
-      "screens.Onboarding.AddToProjectScreen.ScanQrCodeStep.instructionsTitle",
+    id: "screens.AddToProjectScreen.ScanQrCodeStep.instructionsTitle",
     defaultMessage: "Instructions",
   },
   instructionsDescription: {
-    id:
-      "screens.Onboarding.AddToProjectScreen.ScanQrCodeStep.instructionsDescription",
+    id: "screens.AddToProjectScreen.ScanQrCodeStep.instructionsDescription",
     defaultMessage: "Scan device to add person to project",
   },
   havingTroubleTitle: {
-    id: "screens.Onboarding.AddToProjectScreen.ScanQrCodeStep.havingTrouble",
+    id: "screens.AddToProjectScreen.ScanQrCodeStep.havingTrouble",
     defaultMessage: "Having trouble?",
   },
   havingTroubleDescription: {
-    id:
-      "screens.Onboarding.AddToProjectScreen.ScanQrCodeStep.havingTroubleDescription",
+    id: "screens.AddToProjectScreen.ScanQrCodeStep.havingTroubleDescription",
     defaultMessage: "Ask community Mapper to send join request",
   },
 });

--- a/src/frontend/screens/AddToProjectScreen/SuccessStep.tsx
+++ b/src/frontend/screens/AddToProjectScreen/SuccessStep.tsx
@@ -7,15 +7,15 @@ import { WHITE } from "../../lib/styles";
 
 const m = defineMessages({
   title: {
-    id: "screens.Onboarding.AddToProjectScreen.SuccessStep.title",
+    id: "screens.AddToProjectScreen.SuccessStep.title",
     defaultMessage: "Success!",
   },
   description: {
-    id: "screens.Onboarding.AddToProjectScreen.SuccessStep.description",
+    id: "screens.AddToProjectScreen.SuccessStep.description",
     defaultMessage: "{deviceId} has been added to {projectName}",
   },
   goToSync: {
-    id: "screens.Onboarding.AddToProjectScreen.SuccessStep.goToSync",
+    id: "screens.AddToProjectScreen.SuccessStep.goToSync",
     defaultMessage: "Go To Sync",
   },
 });


### PR DESCRIPTION
Part of #666 that I forgot to implement in #682 

Notes:
- updates the message ids for the add to project steps
- adjusted action in success step to navigate to home screen (map), mostly just for QA purposes so you're not stuck in the add to project flow loop

---

Preview:

![add-to-project-flow](https://user-images.githubusercontent.com/18542095/129637045-6dc5a5e7-38f8-401f-a496-951dbf1d6ec5.gif)


