### PR TITLE
Add invite param to path for ProjectInviteModal

### DIFF
--- a/src/frontend/NavigationStacks/WithModalsStack.tsx
+++ b/src/frontend/NavigationStacks/WithModalsStack.tsx
@@ -18,7 +18,10 @@ const MainStack = createSwitchNavigator(
 export const WithModalsStack = createStackNavigator(
   {
     Main: MainStack,
-    ProjectInviteModal,
+    ProjectInviteModal: {
+      screen: ProjectInviteModal,
+      path: "ProjectInviteModal/:invite",
+    },
   },
   {
     initialRouteName: "Main",


### PR DESCRIPTION
This allows deeplinks in the form of `mapeo://ProjectInviteModal/:invite` to work (whether for QA or for improving ease of sharing) 