### PR TITLE
chore(tests): Skip waiting for map to completely load in e2e tests

### DIFF
--- a/e2e/setup.ts
+++ b/e2e/setup.ts
@@ -2,4 +2,5 @@
 
 beforeAll(async () => {
   await device.launchApp();
+  await device.setURLBlacklist([".*api.mapbox.com.*"]);
 });


### PR DESCRIPTION
Currently e2e tests wait for all network activity to finish before
continuing with each test step. The Mapbox library can continue
pre-loading tiles for a while and slows down tests.

Came across this when setting up tests for the Mapeo ICCA variant