### PR TITLE
chore: enable TestButler for e2e tests

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -204,7 +204,7 @@ android {
 
         // Detox integration
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
-        testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
+        testInstrumentationRunner 'com.mapeo.DetoxTestAppJUnitRunner'
     }
     splits {
         abi {
@@ -360,7 +360,8 @@ dependencies {
     implementation 'androidx.swiperefreshlayout:swiperefreshlayout:1.1.0-alpha02'
 
     // Detox
-    androidTestImplementation('com.wix:detox:+')
+    androidTestImplementation 'com.wix:detox:+'
+    androidTestImplementation 'com.linkedin.testbutler:test-butler-library:2.2.1'
 }
 
 // Run this once to be able to run the application with BUCK

--- a/android/app/src/androidTest/java/com/mapeo/DetoxTest.java
+++ b/android/app/src/androidTest/java/com/mapeo/DetoxTest.java
@@ -20,9 +20,10 @@ public class DetoxTest {
     public ActivityTestRule<MainActivity> mActivityRule = new ActivityTestRule<>(MainActivity.class, false, false);
 
     @Test
-    public void runDetoxTests() {// This is optional - in case you've decided to integrate TestButler
+    public void runDetoxTests() {
+        // This is optional - in case you've decided to integrate TestButler
         // See https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md#8-test-butler-support-optional
-        // TestButlerProbe.assertReadyIfInstalled();
+        TestButlerProbe.assertReadyIfInstalled();
 
         DetoxConfig detoxConfig = new DetoxConfig();
         detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;

--- a/android/app/src/androidTest/java/com/mapeo/DetoxTestAppJUnitRunner.java
+++ b/android/app/src/androidTest/java/com/mapeo/DetoxTestAppJUnitRunner.java
@@ -1,0 +1,21 @@
+package com.mapeo;
+
+import android.os.Bundle;
+
+import com.linkedin.android.testbutler.TestButler;
+
+import androidx.test.runner.AndroidJUnitRunner;
+
+public class DetoxTestAppJUnitRunner extends AndroidJUnitRunner {
+    @Override
+    public void onStart() {
+        TestButler.setup(getTargetContext());
+        super.onStart();
+    }
+
+    @Override
+    public void finish(int resultCode, Bundle results) {
+        TestButler.teardown(getTargetContext());
+        super.finish(resultCode, results);
+    }
+}

--- a/android/app/src/androidTest/java/com/mapeo/TestButlerProbe.java
+++ b/android/app/src/androidTest/java/com/mapeo/TestButlerProbe.java
@@ -1,0 +1,49 @@
+package com.mapeo;
+
+import android.content.pm.PackageManager;
+import android.util.Log;
+import android.view.Surface;
+
+import com.linkedin.android.testbutler.TestButler;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+class TestButlerProbe {
+
+    private static final String LOG_TAG = TestButlerProbe.class.getSimpleName();
+    private static final String TEST_BUTLER_PACKAGE_NAME = "com.linkedin.android.testbutler";
+
+    private TestButlerProbe() {
+    }
+
+    static void assertReadyIfInstalled() {
+        Log.i(LOG_TAG, "Test butler service verification started...");
+
+        if (!isTestButlerServiceInstalled()) {
+            Log.w(LOG_TAG, "Test butler not installed on device - skipping verification");
+            return;
+        }
+
+        assertTestButlerServiceReady();
+        Log.i(LOG_TAG, "Test butler service is up and running!");
+    }
+
+    static private boolean isTestButlerServiceInstalled() {
+        try {
+            PackageManager pm = InstrumentationRegistry.getInstrumentation().getTargetContext().getPackageManager();
+            pm.getPackageInfo(TEST_BUTLER_PACKAGE_NAME, 0);
+            return true;
+        } catch (PackageManager.NameNotFoundException e) {
+            return false;
+        }
+    }
+
+    static private void assertTestButlerServiceReady() {
+        try {
+            // This has no effect if test-butler is running. However, if it is not, then unlike TestButler.setup(), it would hard-fail.
+            TestButler.setRotation(Surface.ROTATION_0);
+        } catch (Exception e) {
+            throw new RuntimeException("Test butler service is NOT ready!", e);
+        }
+    }
+}


### PR DESCRIPTION
See https://github.com/wix/Detox/blob/master/docs/Introduction.Android.md#8-test-butler-support-optional

I have not noticed a difference, but might help in CI. Spotted this when debugging another Detox testing issue.