### PR TITLE
chore: cache nodejs-native-assets

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -93,9 +93,18 @@ jobs:
       - name: Build translations
         run: |
           npm run build:translations
+      - name: nodejs-mobile build cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: android/build/nodejs-native-assets
+          key: ${{ runner.os }}-nodejs-mobile-${{ hashFiles('src/backend/package-lock.json') }}
       - name: Build for detox
-        run: |
-          npm run build-detox-android
+        run: npm run build-detox-android
+        env:
+          # If we have cached the nodejs-native-assets, then we do not need
+          # to build native modules, so we set this to "0"
+          NODEJS_MOBILE_BUILD_NATIVE_MODULES: ${{ steps.cache.outputs.cache-hit == 'true' && '0' || '1' }}
       - name: Android Emulator
         timeout-minutes: 10
         continue-on-error: true

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -185,6 +185,18 @@ bugsnag {
     sharedObjectPath "app/build/jni/libs"
 }
 
+String shouldRebuildNativeModules = System.getenv('NODEJS_MOBILE_BUILD_NATIVE_MODULES');
+
+// This is from the nodejs-mobile build.gradle, but it is only set if
+// NODEJS_MOBILE_BUILD_NATIVE_MODULES is "1". When we cache the native modules
+// build files we set NODEJS_MOBILE_BUILD_NATIVE_MODULES to "0", but we still
+// want to include this folder in the build
+if ("0".equals(shouldRebuildNativeModules)) {
+    // We are not rebuilding native modules, but we still want to include the
+    // cached native module build files in the build
+    project.android.sourceSets.main.assets.srcDirs+="${rootProject.buildDir}/nodejs-native-assets/"
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion


### PR DESCRIPTION
Every CI run we rebuild leveldb for Android, which takes 15-20 minutes. We are locking the version of leveldb in `src/backend/package-lock.json` so there is no need to rebuild it every time. This is an attempt to cache the built leveldb to avoid having to rebuild it on each CI run. Hopefully this will speed up CI runs on Github significantly.

The better solution to this is probably to publish our own leveldown package on npm with prebuilds for Android, but I'm not so sure how to do that right now.