### PR TITLE
chore: cache gradle dependencies

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -93,6 +93,14 @@ jobs:
       - name: Build translations
         run: |
           npm run build:translations
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - name: Build for detox
         run: |
           npm run build-detox-android
@@ -114,3 +122,9 @@ jobs:
         with:
           name: test-videos
           path: artifacts
+      - name: Cleanup Gradle Cache
+        # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
+        # Restoring these files from a GitHub Actions cache might cause problems for future builds.
+        run: |
+          rm -f ~/.gradle/caches/modules-2/modules-2.lock
+          rm -f ~/.gradle/caches/modules-2/gc.properties


### PR DESCRIPTION
Cache Gradle dependencies, to speed up builds and avoid issues with downloads from package repositories not working (we have had issues with Groovy downloads failing, and also outages with jcenter)