### PR TITLE
chore: speedup CI e2e tests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -41,6 +41,12 @@ jobs:
           key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
             ${{ runner.os }}-node-
+      - name: Cache Gradle files
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
       - name: Node
         uses: actions/setup-node@v1
       - name: Use specific Java version for sdkmanager to work

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -125,17 +125,19 @@ jobs:
           kextstat | grep intel
           echo "\nEmulator config"
           cat $HOME/.android/avd/emu.avd/config.ini
-      - name: Install node_modules
-        run: |
-          mkdir -p nodejs-assets
-          npm ci
-      - name: Android Emulator
-        timeout-minutes: 10
-        continue-on-error: true
+      - name: Start Android Emulator
         run: |
           echo "Starting emulator"
           mkdir -p artifacts
           nohup $ANDROID_HOME/emulator/emulator -avd emu -no-audio -no-snapshot -no-window -gpu swiftshader_indirect -camera-back emulated -no-boot-anim &
+      - name: Install node_modules
+        run: |
+          mkdir -p nodejs-assets
+          npm ci
+      - name: Wait for Android Emulator
+        timeout-minutes: 10
+        continue-on-error: true
+        run: |
           $ANDROID_HOME/platform-tools/adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed | tr -d '\r') ]]; do sleep 1; done; input keyevent 82'
           $ANDROID_HOME/platform-tools/adb devices
           echo "Emulator started"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -135,7 +135,8 @@ jobs:
       - name: Install node_modules
         run: |
           mkdir -p nodejs-assets
-          npm ci
+          # We are only running detox here, so we don't need the postinstall scripts to run
+          npm ci --ignore-scripts
       - name: Wait for Android Emulator
         timeout-minutes: 10
         continue-on-error: true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -114,6 +114,8 @@ jobs:
           sdkmanager --update | grep -v = || true
           echo "SDK versions:"
           $ANDROID_HOME/tools/bin/sdkmanager --list
+          echo "Install latest emulator"
+          $ANDROID_HOME/tools/bin/sdkmanager --install emulator > /dev/null
           echo "Downloading emulator image"
           echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-28;default;x86_64" > /dev/null
           echo "Creating emulator avd"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -145,7 +145,7 @@ jobs:
           $ANDROID_HOME/platform-tools/adb devices
           echo "Emulator started"
       - name: Android Detox
-        run: npm start & npm run test-detox-android -- -l verbose --headless --record-videos all --record-logs all
+        run: npm start & npm run test-detox-android -- --headless --record-videos all --record-logs all
       - name: Upload artifacts
         uses: actions/upload-artifact@v1
         if: always()

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -34,6 +34,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Cache npm files
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
       - name: Node
         uses: actions/setup-node@v1
       - name: Use specific Java version for sdkmanager to work

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,26 +27,13 @@ jobs:
         run: |
           cd src/backend
           npm test
-  e2e-tests:
+  e2e-build:
     if: github.event.pull_request.draft == false
-    name: e2e tests
-    runs-on: macos-latest
+    name: e2e build
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      # - name: Cache npm files
-      #   uses: actions/cache@v1
-      #   with:
-      #     path: ~/.npm
-      #     key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-      #     restore-keys: |
-      #       ${{ runner.os }}-node-
-      # - name: Cache Gradle files
-      #   uses: actions/cache@v1
-      #   with:
-      #     path: ~/.gradle/caches
-      #     key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-      #     restore-keys: ${{ runner.os }}-gradle-
       - name: Node
         uses: actions/setup-node@v1
       - name: Use specific Java version for sdkmanager to work
@@ -54,19 +41,52 @@ jobs:
         with:
           java-version: "openjdk8"
           architecture: "x64"
-      # - name: Install NDK
-      #   run: |
-      #     export ANDROID_NDK_VERSION='20b'
-      #     export ANDROID_NDK_HOME=$ANDROID_HOME/ndk-bundle
-      #     curl -fsSo android-ndk-r${ANDROID_NDK_VERSION}.zip https://dl.google.com/android/repository/android-ndk-r${ANDROID_NDK_VERSION}-linux-x86_64.zip
-      #     unzip -q -o android-ndk-r${ANDROID_NDK_VERSION}.zip
-      #     rm -rf $ANDROID_NDK_HOME
-      #     mv android-ndk-r${ANDROID_NDK_VERSION} $ANDROID_NDK_HOME
-      #     ls -al $ANDROID_NDK_HOME
-      #     cat $ANDROID_NDK_HOME/source.properties
+      # Our build will otherwise use NDK 22, which does not work.
       - name: Delete newer NDK version
+        run: rm -rf $ANDROID_HOME/ndk/22*
+      - name: Install node_modules
         run: |
-          rm -rf $ANDROID_HOME/ndk/22*
+          mkdir -p nodejs-assets
+          npm ci
+      - name: Build backend
+        run: |
+          npm run build:backend
+      - name: Build translations
+        run: |
+          npm run build:translations
+      - name: Build for detox
+        run: |
+          npm run build-detox-android
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: outputs-apk
+          path: android/app/build/outputs/apk
+  e2e-tests:
+    needs: e2e-build
+    name: e2e tests
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - uses: actions/download-artifact@v2
+        with:
+          name: outputs-apk
+          path: android/app/build/outputs/apk
+      - name: Cache npm files
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+      - name: Node
+        uses: actions/setup-node@v1
+      - name: Use specific Java version for sdkmanager to work
+        uses: joschi/setup-jdk@v2
+        with:
+          java-version: "openjdk8"
+          architecture: "x64"
       - name: Download Android Emulator Image
         run: |
           sdkmanager --update | grep -v = || true
@@ -87,15 +107,6 @@ jobs:
         run: |
           mkdir -p nodejs-assets
           npm ci
-      - name: Build backend
-        run: |
-          npm run build:backend
-      - name: Build translations
-        run: |
-          npm run build:translations
-      - name: Build for detox
-        run: |
-          npm run build-detox-android
       - name: Android Emulator
         timeout-minutes: 10
         continue-on-error: true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,6 +47,12 @@ jobs:
           path: ~/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: ${{ runner.os }}-gradle-
+      - name: nodejs-mobile build cache
+        id: cache
+        uses: actions/cache@v2
+        with:
+          path: android/build/nodejs-native-assets
+          key: ${{ runner.os }}-nodejs-mobile-${{ hashFiles('src/backend/package-lock.json') }}
       - name: Node
         uses: actions/setup-node@v1
       - name: Use specific Java version for sdkmanager to work
@@ -68,8 +74,11 @@ jobs:
         run: |
           npm run build:translations
       - name: Build for detox
-        run: |
-          npm run build-detox-android
+        run: npm run build-detox-android
+        env:
+          # If we have cached the nodejs-native-assets, then we do not need
+          # to build native modules, so we set this to "0"
+          NODEJS_MOBILE_BUILD_NATIVE_MODULES: ${{ steps.cache.outputs.cache-hit == 'true' && '0' || '1' }}
       - name: Upload artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -115,9 +115,9 @@ jobs:
           echo "SDK versions:"
           $ANDROID_HOME/tools/bin/sdkmanager --list
           echo "Downloading emulator image"
-          echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-28;default;x86" > /dev/null
+          echo "y" | $ANDROID_HOME/tools/bin/sdkmanager --install "system-images;android-28;default;x86_64" > /dev/null
           echo "Creating emulator avd"
-          echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd --force --name emu --device "Nexus 6" -k 'system-images;android-28;default;x86'
+          echo "no" | $ANDROID_HOME/tools/bin/avdmanager create avd --force --name emu --device "Nexus 6" -k 'system-images;android-28;default;x86_64'
           echo "Emulator version:"
           $ANDROID_HOME/emulator/emulator @emu -version
           echo "Hardware acceleration:"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -185,6 +185,18 @@ bugsnag {
     sharedObjectPath "app/build/jni/libs"
 }
 
+String shouldRebuildNativeModules = System.getenv('NODEJS_MOBILE_BUILD_NATIVE_MODULES');
+
+// This is from the nodejs-mobile build.gradle, but it is only set if
+// NODEJS_MOBILE_BUILD_NATIVE_MODULES is "1". When we cache the native modules
+// build files we set NODEJS_MOBILE_BUILD_NATIVE_MODULES to "0", but we still
+// want to include this folder in the build
+if ("0".equals(shouldRebuildNativeModules)) {
+    // We are not rebuilding native modules, but we still want to include the
+    // cached native module build files in the build
+    project.android.sourceSets.main.assets.srcDirs+="${rootProject.buildDir}/nodejs-native-assets/"
+}
+
 android {
     compileSdkVersion rootProject.ext.compileSdkVersion
     buildToolsVersion rootProject.ext.buildToolsVersion

--- a/detox.config.js
+++ b/detox.config.js
@@ -35,7 +35,7 @@ module.exports = {
       binaryPath:
         "android/app/build/outputs/apk/app/universal/mapeo-app-universal.apk",
       build:
-        "cd android && ./gradlew app:assembleUniversal app:assembleAndroidTest -DtestBuildType=universal && cd ..",
+        "cd android && ./gradlew --parallel app:assembleAppUniversal app:assembleAndroidTest -DtestBuildType=universal && cd ..",
     },
     "android.debug": {
       type: "android.apk",


### PR DESCRIPTION
This PR attempts to increase the speed of end-to-end tests that run on Github actions. These tests have been taking 35-40 minutes to complete. This PR includes several changes, each of which should make incremental gains to the test speed:

- [x] **Build on Ubuntu**. Currently we build and run tests on MacOS. The tests need to run on MacOS because only the MacOS images on Github actions have hardware acceleration for the Android emulator. The Android emulator runs incredibly slowly on the Github Actions Ubuntu image. However, the build step is much faster on Ubuntu. This change builds the test APKs first on Ubuntu, then uses those APKs to run the e2e tests on MacOS.
- [x] **npm & Gradle dependency cache**. We cache the dependencies used by npm and Gradle. This results in a small speed up (the cost of loading the cache is close to the speed gain) but importantly it also avoids problems we have seen with errors from Gradle repositories causing the dependency download to fail, resulting in a failing test.
- [x] **nodejs-mobile native module cache**. Building native modules for nodejs-mobile is one of the most costly steps in the build. Mapeo Mobile needs leveldb to be built for Android. However, this rarely changes between builds, so we can cache the built leveldb between test runs to avoid building it every time.
- [x] **Gradle parallel builds**. Pass the `--parallel` option to Gradle. Results in a small speed increase, and does not (yet) seem to have adverse side-effects.
- [x] **Start emulator in the background**. Currently we start the emulator, then wait for it to boot before continuing. We can save some time by starting the emulator in the background and executing a different task whilst it boots.
- [x] **Switch to 64-bit emulator image**. We were using a 32-bit Android image. The 64-bit image seems to run a bit faster.
- [x] **Latest emulator version**. Not sure about the speedup, but hopefully installing the latest (30.8.4) version of the emulator vs the default (30.7) will improve the emulator
- [x] **Turn off verbose Detox logging**. This was on for debugging, but seems to slow down the test run a bit.
- [x] **Turn off postinstall scripts**. For the e2e test job we do not need any of the postinstall scripts to run (the scripts are used for Detox iOS builds and for React Native build steps). Skipping these scripts improves the `npm ci` time.

Together these changes seem to improve the build+test time from 35-40 minutes to about 25 minutes. The Android build step (`npm run build-detox-android`) in particular has been reduced from 20-25 minutes to 11-12 minutes. There is still a cost of splitting the task across two jobs - build on Ubuntu then test on MacOS - but the speed gains are worth it. It's hard to benchmark because it seems like the speed of the Github Actions MacOS instances varies a lot, but seems like this should shave some time off our builds overall.

**Future steps**
We might be able to speed up builds by using a specialized build service like [EAS Build](https://docs.expo.dev/build/introduction/). However about half the time is running the e2e tests in the emulator, which is still quite slow even with just a handful of tests. Genymotion integrates with Detox for running e2e tests on an emulator on their infrastructure, but it is expensive. We might have to stick with this free option (Github actions) for now.