### PR TITLE
chore: Run Github actions on every push to develop branch

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,5 +1,8 @@
 name: Android
 on:
+  push:
+    branches:
+      - develop
   pull_request:
     # By default, a workflow only runs when a pull_request 's activity type is
     # opened , synchronize , or reopened. Adding ready_for_review here ensures


### PR DESCRIPTION
If we don't do this then the Github Actions caches are never available
to the PRs to develop. Also, it is helpful to be able to check the
history of `develop` to ensure that each commit passes.