### PR TITLE
fix: fix merging of settings state in settings context

### DIFF
--- a/src/frontend/context/SettingsContext.js
+++ b/src/frontend/context/SettingsContext.js
@@ -52,7 +52,7 @@ export const SettingsProvider = ({ children }: { children: React.Node }) => {
   const contextValue: SettingsContextType = React.useMemo(() => {
     // If we add any new properties to the settings state, they will be
     // undefined in a users' persisted state, so we merge in the defaults
-    const mergedState = merge({}, state, DEFAULT_SETTINGS);
+    const mergedState = merge({}, DEFAULT_SETTINGS, state);
     return [mergedState, setSettings];
   }, [state, setSettings]);
 


### PR DESCRIPTION
Updates are applied left to right according to the [docs](https://docs-lodash.com/v4/merge/) so I think we'd want the existing values in the default settings to be overridden by values defined in the new state. Otherwise some user-defined changes can potentially be overridden by a default value (e.g. coordinate system format)