### PR TITLE
fix: Fix icons with same name not changing when config changes

### DIFF
--- a/src/frontend/api.js
+++ b/src/frontend/api.js
@@ -163,11 +163,11 @@ export function Api({
 }) {
   let status: ServerStatus = STATUS.IDLE;
   let timeoutId: TimeoutID;
-  // We append this to requests for presets and map styles, in order to override
-  // the local static server cache whenever the app is restarted. NB. sprite,
-  // font, and map tile requests might still be cached, only changes in the map
-  // style will be cache-busted.
-  const startupTime = Date.now();
+  // We append this to requests for presets, icons and map styles, in order to
+  // override the local static server cache whenever the app is restarted. NB.
+  // sprite, font, and map tile requests might still be cached, only changes in
+  // the map style will be cache-busted.
+  let startupTime = Date.now();
 
   const req = ky.extend({
     prefixUrl: baseUrl,
@@ -456,8 +456,12 @@ export function Api({
 
             function done(err) {
               clearTimeout(timeoutId);
-              if (err) reject(err);
-              else resolve();
+              if (err) return reject(err);
+              // startupTime is use for cache-busting. When we replace the
+              // config we want the cache to be reset so that icons with the
+              // same name are not cached
+              startupTime = Date.now();
+              resolve();
             }
           })
       );

--- a/src/frontend/api.js
+++ b/src/frontend/api.js
@@ -563,7 +563,7 @@ export function Api({
       // Some devices are @4x or above, but we only generate icons up to @3x
       // Also we don't have @1.5x, so we round it up
       const roundedRatio = Math.min(Math.ceil(pixelRatio), 3);
-      return `${BASE_URL}presets/default/icons/${iconId}-medium@${roundedRatio}x.png`;
+      return `${BASE_URL}presets/default/icons/${iconId}-medium@${roundedRatio}x.png?{startupTime}`;
     },
 
     // Return the url for a media attachment

--- a/src/frontend/api.js
+++ b/src/frontend/api.js
@@ -563,7 +563,7 @@ export function Api({
       // Some devices are @4x or above, but we only generate icons up to @3x
       // Also we don't have @1.5x, so we round it up
       const roundedRatio = Math.min(Math.ceil(pixelRatio), 3);
-      return `${BASE_URL}presets/default/icons/${iconId}-medium@${roundedRatio}x.png?{startupTime}`;
+      return `${BASE_URL}presets/default/icons/${iconId}-medium@${roundedRatio}x.png?${startupTime}`;
     },
 
     // Return the url for a media attachment


### PR DESCRIPTION
Fixes #727 

Category icons are cached by the device, so that even if the underlying resource changes, the displayed icon does not change. This PR adds a query parameter to the preset icon URLs that is updated when the user changes the config or when the user restarts the app. The query parameter ensure that the URL is not considered the same by the device caching.
