### PR TITLE
chore: Improve BottomSheetModal implementation

### DIFF
--- a/src/frontend/screens/JoinRequestModal.tsx
+++ b/src/frontend/screens/JoinRequestModal.tsx
@@ -14,7 +14,7 @@ import {
   MODAL_NAVIGATION_OPTIONS,
   BottomSheetModal,
   BottomSheetContent,
-  useBottomSheetRef,
+  useBottomSheetModal,
 } from "../sharedComponents/BottomSheetModal";
 import { DoneIcon } from "../sharedComponents/icons";
 import Circle from "../sharedComponents/icons/Circle";
@@ -56,18 +56,13 @@ export const JoinRequestModal: NavigationStackScreenComponent<{
   const [loading, setLoading] = React.useState(false);
   const [step, setStep] = React.useState<"prompt" | "success">("prompt");
 
-  const sheetRef = useBottomSheetRef();
   const [config] = React.useContext(ConfigContext);
+
+  const { sheetRef, closeSheet } = useBottomSheetModal({ openOnMount: true });
 
   const projectName = config.metadata.name;
   const deviceName = navigation.getParam("deviceName");
   const key = navigation.getParam("key");
-
-  const closeModal = () => {
-    if (sheetRef.current) {
-      sheetRef.current.dismiss();
-    }
-  };
 
   // TODO: do something with `key` here
   const invite = async () => {
@@ -83,12 +78,6 @@ export const JoinRequestModal: NavigationStackScreenComponent<{
     setStep("success");
   };
 
-  React.useEffect(() => {
-    if (sheetRef.current) {
-      sheetRef.current.present();
-    }
-  }, []);
-
   return (
     <BottomSheetModal ref={sheetRef} onDismiss={navigation.goBack}>
       {step === "prompt" ? (
@@ -96,7 +85,7 @@ export const JoinRequestModal: NavigationStackScreenComponent<{
           buttonConfigs={[
             {
               variation: "outlined",
-              onPress: closeModal,
+              onPress: closeSheet,
               text: t(m.denyRequest),
             },
             {
@@ -117,7 +106,7 @@ export const JoinRequestModal: NavigationStackScreenComponent<{
           buttonConfigs={[
             {
               variation: "outlined",
-              onPress: closeModal,
+              onPress: closeSheet,
               text: t(m.close),
             },
           ]}

--- a/src/frontend/screens/ProjectInviteModal.tsx
+++ b/src/frontend/screens/ProjectInviteModal.tsx
@@ -15,7 +15,7 @@ import {
   MODAL_NAVIGATION_OPTIONS,
   BottomSheetModal,
   BottomSheetContent,
-  useBottomSheetRef,
+  useBottomSheetModal,
 } from "../sharedComponents/BottomSheetModal";
 import Text from "../sharedComponents/Text";
 import { DoneIcon } from "../sharedComponents/icons";
@@ -101,8 +101,8 @@ const getProjectInviteDetails = async (
 export const ProjectInviteModal: NavigationStackScreenComponent<{
   invite?: string;
 }> = ({ navigation }) => {
-  const { formatMessage: t, wrapRichTextChunksInFragment } = useIntl();
-  const sheetRef = useBottomSheetRef();
+  const { formatMessage: t } = useIntl();
+  const { sheetRef, closeSheet } = useBottomSheetModal({ openOnMount: true });
 
   const mountedRef = React.useRef(true);
 
@@ -126,17 +126,11 @@ export const ProjectInviteModal: NavigationStackScreenComponent<{
         setStatus({ type: "success", info: { inviteDetails } });
       }
     } catch (err) {
-      if (mountedRef.current) {
+      if (mountedRef.current && err instanceof Error) {
         setStatus({ type: "error", info: { error: err } });
       }
     }
   }, []);
-
-  const closeModal = () => {
-    if (sheetRef.current) {
-      sheetRef.current.dismiss();
-    }
-  };
 
   const acceptInvite = () => {
     navigation.navigate("Sync");
@@ -149,10 +143,6 @@ export const ProjectInviteModal: NavigationStackScreenComponent<{
   }, [fetchInviteDetails, inviteKey]);
 
   React.useEffect(() => {
-    if (sheetRef.current) {
-      sheetRef.current.present();
-    }
-
     return () => {
       mountedRef.current = false;
     };
@@ -167,7 +157,7 @@ export const ProjectInviteModal: NavigationStackScreenComponent<{
           buttonConfigs={[
             {
               variation: "outlined",
-              onPress: closeModal,
+              onPress: closeSheet,
               text: t(m.close),
             },
             {
@@ -201,7 +191,7 @@ export const ProjectInviteModal: NavigationStackScreenComponent<{
             {
               text: t(m.declineInvite),
               variation: "outlined",
-              onPress: closeModal,
+              onPress: closeSheet,
             },
             {
               text: t(m.joinAndSync),

--- a/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/Content.tsx
@@ -97,6 +97,7 @@ const styles = StyleSheet.create({
   },
   textContainer: {
     marginVertical: 20,
+    paddingHorizontal: 20,
   },
   title: {
     textAlign: "center",

--- a/src/frontend/sharedComponents/BottomSheetModal/index.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/index.tsx
@@ -15,9 +15,34 @@ export const MODAL_NAVIGATION_OPTIONS = {
   animationEnabled: false,
 };
 
-export const useBottomSheetRef = () => {
+export const useBottomSheetModal = ({
+  openOnMount,
+}: {
+  openOnMount: boolean;
+}) => {
+  const initiallyOpenedRef = React.useRef(false);
   const sheetRef = React.useRef<RNBottomSheetModal>(null);
-  return sheetRef;
+
+  const closeSheet = React.useCallback(() => {
+    if (sheetRef.current) {
+      sheetRef.current.dismiss();
+    }
+  }, []);
+
+  const openSheet = React.useCallback(() => {
+    if (sheetRef.current) {
+      sheetRef.current.present();
+    }
+  }, []);
+
+  React.useEffect(() => {
+    if (!initiallyOpenedRef.current && openOnMount) {
+      initiallyOpenedRef.current = true;
+      openSheet();
+    }
+  }, [openOnMount, openSheet]);
+
+  return { sheetRef, closeSheet, openSheet };
 };
 
 const useBackPressHandler = (onHardwareBackPress?: () => void) => {


### PR DESCRIPTION
Extracted from changes in #729 

Notes:
- moves closing + opening methods and open-on-mount logic to the `useBottomSheetModal` hook