### PR TITLE
chore: Use more engine-compatible regex expression for positive decimal

### DIFF
--- a/src/frontend/screens/ManualGpsScreen/shared.ts
+++ b/src/frontend/screens/ManualGpsScreen/shared.ts
@@ -11,8 +11,8 @@ export type FormProps = {
   onValueUpdate: (convertedCoordinates: ConvertedCoordinateData) => void;
 };
 
-// https://stackoverflow.com/a/39399503
-export const POSITIVE_DECIMAL_REGEX = /^(0|[1-9]\d*)?(\.\d+)?(?<=\d)$/;
+// Adapted from https://stackoverflow.com/a/7708352
+export const POSITIVE_DECIMAL_REGEX = /^([\d]+(?:[\.][\d]*)?|\.[\d]+)$/;
 
 export const INTEGER_REGEX = /^[0-9]\d*$/;
 


### PR DESCRIPTION
Turns out default JS engine used on iOS doesn't support positive lookbehind syntax ([link](https://caniuse.com/js-regexp-lookbehind)). Don't think it's truly necessary for our use cases. See test cases [here](https://regexr.com/65dbc)