### PR TITLE
Observation view and Observation edit view autofocus

### DIFF
--- a/src/frontend/screens/ObservationDetails/Question.tsx
+++ b/src/frontend/screens/ObservationDetails/Question.tsx
@@ -10,15 +10,14 @@ export type QuestionProps = {
   field: Field;
   value: any;
   onChange: (value: any) => any;
-  autoFocus?: boolean;
 };
 
-const Question = ({ field, autoFocus, ...other }: QuestionProps) => {
+const Question = ({ field, ...other }: QuestionProps) => {
   if (field.type === "select_one" && Array.isArray(field.options)) {
     return <SelectOne {...other} field={field} />;
   } else if (field.type === "select_multiple" && Array.isArray(field.options)) {
     return <SelectMultiple {...other} field={field} />;
-  } else return <TextArea autoFocus={true} {...{ field, ...other }} />;
+  } else return <TextArea {...{ field, ...other }} />;
 };
 
 export default Question;

--- a/src/frontend/screens/ObservationDetails/Question.tsx
+++ b/src/frontend/screens/ObservationDetails/Question.tsx
@@ -1,4 +1,3 @@
-// @flow
 import React from "react";
 
 import SelectOne from "./SelectOne";
@@ -8,19 +7,18 @@ import TextArea from "./TextArea";
 import type { Field } from "../../context/ConfigContext";
 
 export type QuestionProps = {
-  field: Field,
-  value: any,
-  onChange: (value: any) => any,
+  field: Field;
+  value: any;
+  onChange: (value: any) => any;
+  autoFocus?: boolean;
 };
 
-const Question = (props: QuestionProps) => {
-  // This is needed for Flow to understand the type refinement
-  const { field, ...other } = props;
+const Question = ({ field, autoFocus = false, ...other }: QuestionProps) => {
   if (field.type === "select_one" && Array.isArray(field.options)) {
     return <SelectOne {...other} field={field} />;
   } else if (field.type === "select_multiple" && Array.isArray(field.options)) {
     return <SelectMultiple {...other} field={field} />;
-  } else return <TextArea {...props} />;
+  } else return <TextArea {...{ field, autoFocus, ...other }} />;
 };
 
 export default Question;

--- a/src/frontend/screens/ObservationDetails/Question.tsx
+++ b/src/frontend/screens/ObservationDetails/Question.tsx
@@ -13,12 +13,12 @@ export type QuestionProps = {
   autoFocus?: boolean;
 };
 
-const Question = ({ field, autoFocus = false, ...other }: QuestionProps) => {
+const Question = ({ field, autoFocus, ...other }: QuestionProps) => {
   if (field.type === "select_one" && Array.isArray(field.options)) {
     return <SelectOne {...other} field={field} />;
   } else if (field.type === "select_multiple" && Array.isArray(field.options)) {
     return <SelectMultiple {...other} field={field} />;
-  } else return <TextArea {...{ field, autoFocus, ...other }} />;
+  } else return <TextArea autoFocus={true} {...{ field, ...other }} />;
 };
 
 export default Question;

--- a/src/frontend/screens/ObservationDetails/Question.tsx
+++ b/src/frontend/screens/ObservationDetails/Question.tsx
@@ -9,7 +9,7 @@ import type { Field } from "../../context/ConfigContext";
 export type QuestionProps = {
   field: Field;
   value: any;
-  onChange: (value: any) => any;
+  onChange: (value: any) => void;
 };
 
 const Question = ({ field, ...other }: QuestionProps) => {

--- a/src/frontend/screens/ObservationDetails/TextArea.tsx
+++ b/src/frontend/screens/ObservationDetails/TextArea.tsx
@@ -15,7 +15,7 @@ const TextArea = ({ value, field, onChange }: QuestionProps) => (
       multiline
       scrollEnabled={false}
       textContentType="none"
-      autoFocus={true}
+      autoFocus
     />
   </>
 );

--- a/src/frontend/screens/ObservationDetails/TextArea.tsx
+++ b/src/frontend/screens/ObservationDetails/TextArea.tsx
@@ -4,7 +4,7 @@ import QuestionLabel from "./QuestionLabel";
 
 import type { QuestionProps } from "./Question";
 
-const TextArea = ({ value, field, onChange, autoFocus }: QuestionProps) => (
+const TextArea = ({ value, field, onChange }: QuestionProps) => (
   <>
     <QuestionLabel field={field} />
     <TextInput
@@ -15,7 +15,7 @@ const TextArea = ({ value, field, onChange, autoFocus }: QuestionProps) => (
       multiline
       scrollEnabled={false}
       textContentType="none"
-      autoFocus={autoFocus}
+      autoFocus={true}
     />
   </>
 );

--- a/src/frontend/screens/ObservationDetails/TextArea.tsx
+++ b/src/frontend/screens/ObservationDetails/TextArea.tsx
@@ -1,11 +1,10 @@
-// @flow
 import React from "react";
 import { StyleSheet, TextInput } from "react-native";
 import QuestionLabel from "./QuestionLabel";
 
 import type { QuestionProps } from "./Question";
 
-const TextArea = ({ value, field, onChange }: QuestionProps) => (
+const TextArea = ({ value, field, onChange, autoFocus }: QuestionProps) => (
   <>
     <QuestionLabel field={field} />
     <TextInput
@@ -16,6 +15,7 @@ const TextArea = ({ value, field, onChange }: QuestionProps) => (
       multiline
       scrollEnabled={false}
       textContentType="none"
+      autoFocus={autoFocus}
     />
   </>
 );

--- a/src/frontend/screens/ObservationEdit/ObservationEditView.js
+++ b/src/frontend/screens/ObservationEdit/ObservationEditView.js
@@ -137,7 +137,6 @@ const DescriptionField = () => {
           placeholderTextColor="silver"
           underlineColorAndroid="transparent"
           multiline
-          autoFocus={true}
           scrollEnabled={false}
           textContentType="none"
           testID="observationDescriptionField"

--- a/src/frontend/screens/ObservationEdit/ObservationEditView.js
+++ b/src/frontend/screens/ObservationEdit/ObservationEditView.js
@@ -137,7 +137,7 @@ const DescriptionField = () => {
           placeholderTextColor="silver"
           underlineColorAndroid="transparent"
           multiline
-          autoFocus={false}
+          autoFocus={true}
           scrollEnabled={false}
           textContentType="none"
           testID="observationDescriptionField"


### PR DESCRIPTION
# Details:
Previously, the observation view screen and observation edit view screen had placeholder text in the text input forms. This placeholder text was confusing users, as it was ambiguous as to whether the text input was an input or just text.

This PR, auto focuses the text input so that the cursor and keyboard appear when they navigate to these pages, in the hopes of making it obvious that the user is interacting with a text input.

The question.js and textarea.js were converted to tsx files in the process

# Initial issue:
Closes #734 
