### PR TITLE
chore: Fix rename step in bitrise config

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -267,7 +267,7 @@ workflows:
                 done
 
                 # Join the path_list array into a string separated by |
-                IFS=\\| eval 'NEW_APK_PATH_LIST="${new_paths[*]}"'
+                IFS='|' eval 'NEW_APK_PATH_LIST="${new_paths[*]}"'
 
                 # Save the variable to the env so it is accessible in other build steps
                 envman add --key BITRISE_APK_PATH_LIST --value "$NEW_APK_PATH_LIST"


### PR DESCRIPTION
We execute this line multiple times in other bitrise flows and I noticed that there was a discrepancy here. Tested it on a shell  playground and turns out that this is not the intended value for `IFS`. This fixes the delimiter to be `'|'` (literal) instead of whatever `\\|` evaluates to