### PR TITLE
chore: Remove NDK 23 in CI when building

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -63,9 +63,9 @@ jobs:
         with:
           java-version: "openjdk8"
           architecture: "x64"
-      # Our build will otherwise use NDK 22, which does not work.
-      - name: Delete newer NDK version
-        run: rm -rf $ANDROID_HOME/ndk/22*
+      # Our build will otherwise use NDK 22 or 23, which does not work.
+      - name: Delete newer NDK versions
+        run: rm -rf $ANDROID_HOME/ndk/{22,23}*
       - name: Install node_modules
         run: |
           mkdir -p nodejs-assets


### PR DESCRIPTION
Looks like GitHub updated the environment so NDK 23 is included (see [example failure](https://github.com/digidem/mapeo-mobile/runs/3757652905#step:12:1206)), which we need to remove prior to building the app.