### PR TITLE
fix: fix crash on Android 10 [WIP]

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -67,8 +67,20 @@ android_test_task:
   artifact_cache:
     folder: android/app/build/outputs/apk
     fingerprint_script: echo $CIRRUS_BUILD_ID
-  create_device_script: |
-    echo no | avdmanager create avd --force --name emu --device "Nexus 6" -k 'system-images;android-28;default;x86_64'
+  matrix:
+    - name: Android 8.1
+      create_device_script: |
+        echo no | avdmanager create avd --force --name emu --device "Nexus 6" -k 'system-images;android-27;default;x86_64'
+    - name: Android 9.0
+      create_device_script: |
+        echo no | avdmanager create avd --force --name emu --device "Nexus 6" -k 'system-images;android-28;default;x86_64'
+    - name: Android 10.0
+      create_device_script: |
+        echo no | avdmanager create avd --force --name emu --device "Nexus 6" -k 'system-images;android-29;default;x86_64'
+    - name: Android 11.0
+      create_device_script: |
+        echo no | avdmanager create avd --force --name emu --device "Nexus 6" -k 'system-images;android-30;default;x86_64'
+  check_emulator_version_script: |
     echo "Emulator version:"
     $ANDROID_HOME/emulator/emulator @emu -version
     echo "Hardware acceleration:"


### PR DESCRIPTION
App currently crashes on Android 10. Hopefully this will be fixed by updating to latest React Native. Kicking this off with updating e2e tests to run on multiple versions of Android, to catch issues like this in the future. Will see how long the tests take, we may not be able to run on all platforms for every commit.

- [x] Update e2e tests to run on Android 8.1, 9.0, 10.0, 11.0
- [ ] Update to RN 0.66
- [ ] Apply patches to nodejs-mobile

