### PR TITLE
fix: Do not surface Practice Mode in config details in settings

### DIFF
--- a/src/frontend/screens/Settings/ProjectConfig/ConfigDetails.tsx
+++ b/src/frontend/screens/Settings/ProjectConfig/ConfigDetails.tsx
@@ -68,7 +68,7 @@ export const ConfigDetails = ({
           {isPracticeMode ? (
             <FormattedMessage {...m.practiceModeName} />
           ) : (
-            `${name} ${version && " v" + version}`
+            `${name}${version ? " " + formatDisplayedVersion(version) : ""}`
           )}
         </Text>
       </View>
@@ -104,6 +104,10 @@ export const ConfigDetails = ({
     )}
   </View>
 );
+
+function formatDisplayedVersion(version: string) {
+  return version.toLowerCase().startsWith("v") ? version : `v${version}`;
+}
 
 const styles = StyleSheet.create({
   container: {

--- a/src/frontend/screens/Settings/ProjectConfig/index.tsx
+++ b/src/frontend/screens/Settings/ProjectConfig/index.tsx
@@ -60,7 +60,7 @@ export const ProjectConfig = () => {
 
   const loading = status === "loading" || config.status === "loading";
 
-  const isPracticeMode = isInPracticeMode(config);
+  const isPracticeMode = experiments.onboarding && isInPracticeMode(config);
 
   const handleImportPress = React.useCallback(async () => {
     setStatus("loading");


### PR DESCRIPTION
Fixes #850

Notes:
- Restores the originally surfaced config details i.e. in the case of the default config: the name of the default config + its version and its project key

Preview:

![850-config-details-default](https://user-images.githubusercontent.com/18542095/138341655-ce3d941b-19cf-4a7e-b97a-b25484656895.png)
