### PR TITLE
fix: Update ObservationView to fix issues from observation types refactor

### DIFF
--- a/src/frontend/screens/Observation/ObservationShare.js
+++ b/src/frontend/screens/Observation/ObservationShare.js
@@ -55,12 +55,11 @@ export const ShareMessage = ({ observation, preset }: ShareMessageProps) => {
   const { formatMessage: t } = useIntl();
   const coordinateFormat = useSettingsValue("coordinateFormat");
 
-  const { value } = observation;
-  const { lon, lat } = value;
+  const { lat, lon, tags } = observation;
 
   const completedFields = preset
     ? preset.fields.filter(f => {
-        const fieldValue = getProp(value.tags, f.key);
+        const fieldValue = getProp(tags, f.key);
         return fieldValue != null && fieldValue !== "";
       })
     : [];
@@ -87,7 +86,7 @@ export const ShareMessage = ({ observation, preset }: ShareMessageProps) => {
           <FormattedCoords format={coordinateFormat} lat={lat} lon={lon} />
         ) : null}
       </p>
-      {value.tags.notes ? <p>{value.tags.notes}</p> : null}
+      {tags.notes ? <p>{tags.notes}</p> : null}
       {completedFields.map((field, idx) => (
         <p key={idx}>
           <b>
@@ -97,7 +96,7 @@ export const ShareMessage = ({ observation, preset }: ShareMessageProps) => {
           <i>
             <FormattedFieldValue
               field={field}
-              value={getProp(value.tags, field.key)}
+              value={getProp(tags, field.key)}
             />
           </i>
         </p>

--- a/src/frontend/screens/Observation/ObservationView.js
+++ b/src/frontend/screens/Observation/ObservationView.js
@@ -138,7 +138,6 @@ const ObservationView = ({
   const icon = (preset && preset.icon) || undefined;
 
   const handleShare = () => {
-    const { value } = observation;
     const msg = renderToString(
       <ShareMessage observation={observation} preset={preset} />,
       { intl }
@@ -148,10 +147,8 @@ const ObservationView = ({
       { intl }
     );
 
-    if (value.attachments && value.attachments.length) {
-      const urls = value.attachments.map(a =>
-        api.getMediaFileUri(a.id, "preview")
-      );
+    if (attachments && attachments.length) {
+      const urls = attachments.map(a => api.getMediaFileUri(a.id, "preview"));
       const options = {
         urls: urls,
         message: msg,


### PR DESCRIPTION
We changed how observations are represented in the app in https://github.com/digidem/mapeo-mobile/pull/870. In a nutshell, we removed the `value` field from an observation in favor of just having its first-level fields representing the value. The nature of the change is best summarized in https://github.com/digidem/mapeo-mobile/pull/870/files#diff-f138c5ddc2e6d420f4ccff6b1475335aec9994fd6490eb4e729d8b73ec84f385R132-R133, but I didn't do a thorough enough search to see what other files needed to be updated, causing an issue with referencing an undefined field. This most broke some functionality in the observation view screen (most noticeably the share feature).

This PR fixes any `.value` references to a saved observation by extracting the desired fields directly from the observation object.