### PR TITLE
feat: Support custom colors for observations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38796,6 +38796,11 @@
         }
       }
     },
+    "validate-color": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/validate-color/-/validate-color-2.2.1.tgz",
+      "integrity": "sha512-1eDb1zqP6W6bbfKKl6dRXObelNoQpW7aF3BUTh2AivWuhcD0pa3ejwURWqrVsyKJMLBMlHLFcM3sj5J+dSFhbg=="
+    },
     "validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",

--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "shallowequal": "^1.1.0",
     "turndown-rn": "^6.1.0",
     "use-memo-one": "^1.1.1",
-    "utm": "^1.1.1"
+    "utm": "^1.1.1",
+    "validate-color": "^2.2.1"
   },
   "devDependencies": {
     "@babel/core": "^7.11.1",


### PR DESCRIPTION
Closes #860 

Notes:
- Essentially identical to https://github.com/digidem/mapeo-desktop/pull/644, though a little easier since we have a context set up for the presets
- Default color is the same orange as used before
- **NOTE**: Current implementation does not update the color of the marker used in the observation screen. Not sure if that's also desired or not

---

Preview:
- Refer to other PR for setup used in demo

![Screenshot_20211220-174547](https://user-images.githubusercontent.com/18542095/146842776-9dc4b442-b5ee-456a-bf11-c1990be1cc91.png)
