### PR TITLE
Use macos 10 image for GitHub CI

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -87,7 +87,7 @@ jobs:
   e2e-tests:
     needs: e2e-build
     name: e2e tests
-    runs-on: macos-latest
+    runs-on: macos-10.15
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
GitHub's change of `macos-latest` to 11 is causing CI issues related to downloading the Android emulator ([example](https://github.com/digidem/mapeo-mobile/runs/4588681745?check_suite_focus=true))

Ideally we'd figure out how to fix our CI to work on the latest but in case we don't want to, here's a PR