### PR TITLE
chore: Update gradle wrapper to use 6.9.2

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -48,7 +48,7 @@ task:
     fingerprint_script: echo $CIRRUS_BUILD_ID
   build_detox_script: npm run build-detox-android
   cleanup_before_cache_script:
-    - rm -rf ~/.gradle/caches/6.2/
+    - rm -rf ~/.gradle/caches/6.9.2/
     - rm -rf ~/.gradle/caches/transforms-1
     - rm -rf ~/.gradle/caches/journal-1
     - rm -rf ~/.gradle/caches/jars-3/*/buildSrc.jar

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
More of a WIP PR right now, but opening to test CI

Suspicion is that 6.9.0 contains a bug causing one of our CI steps to fail sporadically (e.g. https://github.com/digidem/mapeo-mobile/runs/4968297075?check_suite_focus=true). Potentially relevant issue was reported (https://github.com/gradle/gradle/issues/15536) and apparently has been addressed (https://github.com/gradle/gradle/pull/18572). According to https://github.com/gradle/gradle/pull/18572#pullrequestreview-837242221, looks like the fix was backported to 6.9.2

