### PR TITLE
chore(deps): Update mapeo-default-settings to latest

### DIFF
--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -4190,9 +4190,9 @@
       "integrity": "sha512-Yg0AXgJoUeNejwaIrO2ockISve0r3PzRSLhpV6pIt1UYkyplEQKidAO1YRvl4Az02Pkfw/lk6ioAj8upvE70mQ=="
     },
     "mapeo-default-settings": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/mapeo-default-settings/-/mapeo-default-settings-3.5.0.tgz",
-      "integrity": "sha512-Xt+CLKLUZQYkXLdF12QRrMgLyEkMhj7uAYtXDBzOPaytQcRduYM/j2rXe9wICsZZFTizdW8pS3t0CUfKRf9iBA=="
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/mapeo-default-settings/-/mapeo-default-settings-3.6.0.tgz",
+      "integrity": "sha512-m4pupc2u+yihqXDniWp0AoEUX+0DGs7k3shGzOfFszr1l1NMW6FQGX83nO6nisVf2LQv4lTHZSEOniNupXKMnQ=="
     },
     "mapeo-entity-filter": {
       "version": "2.0.0",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -35,7 +35,7 @@
     "level": "^5.0.1",
     "lodash": "^4.17.21",
     "mapeo-config-icca": "^1.4.0",
-    "mapeo-default-settings": "^3.5.0",
+    "mapeo-default-settings": "^3.6.0",
     "mapeo-server": "^17.1.0",
     "mkdirp": "^1.0.4",
     "network-address": "^1.1.2",


### PR DESCRIPTION
Notes:
- Updates `mapeo-default-settings` to latest version (v3.6.0), which most notably adds a default `color` field for various observation categories

Preview:

<img width="272" alt="color-dots-default-config" src="https://user-images.githubusercontent.com/18542095/156228065-965dffc3-773c-4133-be62-110241c27bb4.png">


