### PR TITLE
fix: fix regression in release apk build size

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -227,11 +227,6 @@ android {
         versionName myVersionName
         archivesBaseName = "mapeo"
 
-        // For nodejs-mobile. If this is not set, then nodejs-mobile thinks that this is an empty array, so it does not do any native builds
-        ndk {
-            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
-        }
-
         // Detox integration
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
         testInstrumentationRunner 'com.mapeo.DetoxTestAppJUnitRunner'

--- a/patches/nodejs-mobile-react-native+0.6.3.patch
+++ b/patches/nodejs-mobile-react-native+0.6.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/nodejs-mobile-react-native/android/build.gradle b/node_modules/nodejs-mobile-react-native/android/build.gradle
-index e54f25c..178b15a 100644
+index e54f25c..79b96e2 100644
 --- a/node_modules/nodejs-mobile-react-native/android/build.gradle
 +++ b/node_modules/nodejs-mobile-react-native/android/build.gradle
 @@ -50,6 +50,7 @@ def _isCorrectSTLDefinedByApp = DoesAppAlreadyDefineWantedSTL()
@@ -25,6 +25,15 @@ index e54f25c..178b15a 100644
          main.assets.srcDirs += '../install/resources/nodejs-modules'
      }
  
+@@ -239,7 +242,7 @@ if ("1".equals(shouldRebuildNativeModules)) {
+     GenerateNodeProjectAssetsLists.dependsOn "ApplyPatchScriptToModules"
+ 
+     def nativeModulesABIs = android.defaultConfig.ndk.abiFilters;
+-    if (nativeModulesABIs == null) {
++    if (!nativeModulesABIs) {
+         // No abiFilter is defined for the build. Build native modules for eevery architecture.
+         nativeModulesABIs = ["armeabi-v7a", "x86", "arm64-v8a", "x86_64"] as Set<String>;
+     }
 diff --git a/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java b/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java
 index e882a0c..d5ed11a 100644
 --- a/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java


### PR DESCRIPTION
Turns out that there's no easy way to override the `abiFilters` setting in `defaultConfig` via the `buildTypes` field: https://stackoverflow.com/questions/53322169/how-to-override-defaultconfig-abifilters-in-buildtypes

Specifying the field in `defaultConfig` causes the `buildType`-specific field to be completely ignored, which is why the release build was including all ABIs instead of the ones specified. The solution is to remove that default config specification and patch nodejs-mobile-react-native to properly handle the case where it's not specified in more recent versions of Gradle (handling an empty collection in addition to null)

Preview:

After running `gradlew assembleRelease`:

![image](https://user-images.githubusercontent.com/18542095/158244674-8eacf71f-8955-4d7f-add8-b901d11b285c.png)
