### PR TITLE
Hotfix v5.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.4.1](https://github.com/digidem/mapeo-mobile/compare/v5.4.0...v5.4.1) (2022-03-15)
+
+### Bug Fixes
+
+- fix regression in release apk build size ([2285c5e](https://github.com/digidem/mapeo-mobile/commit/2285c5ef8663f72dd200bd30dcdf21e8f1d439ad))
+
 ## [5.4.0](https://github.com/digidem/mapeo-mobile/compare/v5.3.2...v5.4.0) (2022-01-27)
 
 ### Features

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -227,11 +227,6 @@ android {
         versionName myVersionName
         archivesBaseName = "mapeo"
 
-        // For nodejs-mobile. If this is not set, then nodejs-mobile thinks that this is an empty array, so it does not do any native builds
-        ndk {
-            abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
-        }
-
         // Detox integration
         testBuildType System.getProperty('testBuildType', 'debug')  // This will later be used to control the test apk build type
         testInstrumentationRunner 'com.mapeo.DetoxTestAppJUnitRunner'

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -192,25 +192,13 @@ workflows:
                 set -x
 
                 node ./scripts/gh-pages-redirect.js /icca/latest https://mapeo-apks.s3.amazonaws.com/release-ICCA/${ICCA_RELEASE_APK_PATH##*/}
-      - script@1.1.6:
-          title: Generate release description
-          inputs:
-            - content: |-
-                #!/usr/bin/env bash
-                # fail if any commands fails
-                set -e
-                # debug log
-                set -x
-
-                RELEASE_DESCRIPTION=$(printf "$(npm run --silent release-notes | tail -n +3)\n\n### [Known Issues](KNOWN_ISSUES.md)\n")
-                envman add --key RELEASE_DESCRIPTION --value "$RELEASE_DESCRIPTION"
       - github-release@0.11.0:
           inputs:
             - username: $GITHUB_USERNAME
             - name: $BITRISE_GIT_TAG
             - draft: "no"
             - files_to_upload: $RELEASE_APK_PATH
-            - body: $RELEASE_DESCRIPTION
+            - body: "See [changelog](https://github.com/digidem/mapeo-mobile/blob/develop/CHANGELOG.md) for a detailed list of changes"
             - api_token: $GITHUB_TOKEN
       - google-play-deploy@3.0.2:
           inputs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapeo-mobile",
-  "version": "5.3.2",
+  "version": "5.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapeo-mobile",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "private": true,
   "engines": {
     "node": "12.16.3"

--- a/patches/nodejs-mobile-react-native+0.6.3.patch
+++ b/patches/nodejs-mobile-react-native+0.6.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/nodejs-mobile-react-native/android/build.gradle b/node_modules/nodejs-mobile-react-native/android/build.gradle
-index e54f25c..178b15a 100644
+index e54f25c..79b96e2 100644
 --- a/node_modules/nodejs-mobile-react-native/android/build.gradle
 +++ b/node_modules/nodejs-mobile-react-native/android/build.gradle
 @@ -50,6 +50,7 @@ def _isCorrectSTLDefinedByApp = DoesAppAlreadyDefineWantedSTL()
@@ -25,6 +25,15 @@ index e54f25c..178b15a 100644
          main.assets.srcDirs += '../install/resources/nodejs-modules'
      }
  
+@@ -239,7 +242,7 @@ if ("1".equals(shouldRebuildNativeModules)) {
+     GenerateNodeProjectAssetsLists.dependsOn "ApplyPatchScriptToModules"
+ 
+     def nativeModulesABIs = android.defaultConfig.ndk.abiFilters;
+-    if (nativeModulesABIs == null) {
++    if (!nativeModulesABIs) {
+         // No abiFilter is defined for the build. Build native modules for eevery architecture.
+         nativeModulesABIs = ["armeabi-v7a", "x86", "arm64-v8a", "x86_64"] as Set<String>;
+     }
 diff --git a/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java b/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java
 index e882a0c..d5ed11a 100644
 --- a/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java


### PR DESCRIPTION
Changes:

- Removes the release description generation step from Bitrise since it is flaky and isn't completely necessary
- Fixes a regression in apk size for the release build. Turns out that there's no easy way to override the `abiFilters` setting in `defaultConfig` via the `buildTypes` field: https://stackoverflow.com/questions/53322169/how-to-override-defaultconfig-abifilters-in-buildtypes
    - Specifying the field in `defaultConfig` causes the `buildType`-specific field to be completely ignored, which is why the release build was including all ABIs instead of the ones specified. The solution is to remove that default config specification and patch nodejs-mobile-react-native to properly handle the case where it's not specified in more recent versions of Gradle (handling an empty collection in addition to null)
    - Preview (after running `gradlew assembleRelease`):
      
      ![image](https://user-images.githubusercontent.com/18542095/158244674-8eacf71f-8955-4d7f-add8-b901d11b285c.png)


