### PR TITLE
fix: only support light theme

### DIFF
--- a/android/app/src/main/res/values/styles.xml
+++ b/android/app/src/main/res/values/styles.xml
@@ -1,23 +1,12 @@
 <resources>
 
     <!-- Base application theme. -->
+    <!-- If we want to automatic support for dark theme, change Light to DayNight -->
     <style name="AppTheme" 
-        parent="Theme.AppCompat.DayNight.NoActionBar">
+        parent="Theme.AppCompat.Light.NoActionBar">
         <!-- This stops you seeing a white screen before the spash screen -->
         <item name="android:windowDisablePreview">true</item>
         <!-- Customize your theme here. -->
         <item name="android:textColor">#000000</item>
-        <item name="android:alertDialogTheme">@style/ThemeAlert</item>
     </style>
-
-    <!-- https://stackoverflow.com/a/42533536 -->
-    <style name="ThemeAlert" parent="Theme.AppCompat.DayNight.Dialog.Alert">
-        <!-- Used for the buttons -->
-        <!-- <item name="colorAccent"></item> -->
-        <!-- Used for the title and text -->
-        <item name="android:textColorPrimary">#000000</item>
-        <!-- Used for the background -->
-        <item name="android:background">#ffffff</item>
-    </style>
-
 </resources>


### PR DESCRIPTION
### Notes:

- Via the [RN Diff helper tool](https://github.com/react-native-community/rn-diff-purge/blob/2b62aafb4ac53c02d6747dff571ddfca11354716/RnDiffApp/android/app/src/main/res/values/styles.xml#L4), I introduced a change that basically added support for theme colors to be dynamically switched based on the OS's theme (light, dark, day/night). this - in addition to changes I made to accompany this template change - caused certain text inputs and other ui elements (e.g. picker and alert dialogs) to have completely inconsistent and unusable colors set for them when set to the dark theme. This was most apparent in the manual coordinates input screen. If the OS was in light theme, the colors were usable
- this change reverts the template change so that we tell the app to only support the OS light theme, which is what all of our components and UI are designed for anyways.

---

### Preview (issues were only relevant when in dark theme):

- Text inputs are no longer "invisible". Note that only the inputs in this screen seem to be affected by the issue, not the other ones throughout the app 
    - Before: 
    
      <img width="300" alt="image" src="https://user-images.githubusercontent.com/18542095/162273186-3e049ea4-38c1-4364-8c77-e39488c9ea83.png">
    - After:
    
      <img width="300" alt="image" src="https://user-images.githubusercontent.com/18542095/162274260-22abbeaa-5d80-48bd-8a94-8bc96ae5902a.png">

- Alert dialogs use light theme
    - Before:
    
      <img width="300" alt="image" src="https://user-images.githubusercontent.com/18542095/162273636-49631b97-bd8f-41e3-9e39-841beba939ca.png">

    - After

      <img width="300" alt="image" src="https://user-images.githubusercontent.com/18542095/162274187-85d520d4-b53e-4a8c-a701-3daee6e668fd.png">

