### PR TITLE
fix: ensure all devices get 32-bit and 64-bit ABIs from the Play Store

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -327,6 +327,12 @@ android {
     // applicationVariants are e.g. debug, release
     applicationVariants.all { variant ->
         variant.outputs.each { output ->
+            // The special intel (x86) build type needs to have a different
+            // version code to the release build type if they are to be
+            // published alongside each other on the Play Store
+            if (variant.buildType.name == "intel") {
+                output.versionCodeOverride = 1048576 + defaultConfig.versionCode
+            }
             // For each separate APK per architecture, set a unique version code as described here:
             // https://developer.android.com/studio/build/configure-apk-splits.html
             // Example: versionCode 1 will generate 1001 for armeabi-v7a, 1002 for x86, etc.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -297,7 +297,9 @@ android {
         }
         // Build type for intel devices (chromebooks and rare phones)
         intel {
-            initWith release
+            minifyEnabled enableProguardInReleaseBuilds
+            proguardFiles getDefaultProguardFile("proguard-android.txt"), "proguard-rules.pro"
+            signingConfig signingConfigs.release
             matchingFallbacks = ['release']
             ndk {
                 abiFilters "x86", "x86_64"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -295,6 +295,14 @@ android {
                 abiFilters "armeabi-v7a", "x86", "arm64-v8a", "x86_64"
             }
         }
+        // Build type for intel devices (chromebooks and rare phones)
+        intel {
+            initWith release
+            matchingFallbacks = ['release']
+            ndk {
+                abiFilters "x86", "x86_64"
+            }
+        }
         debug {
             // We need to set this to null so that we can override it for variants
             signingConfig signingConfigs.debug

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -204,8 +204,7 @@ workflows:
           inputs:
             - service_account_json_key_path: $BITRISEIO_SERVICE_ACCOUNT_JSON_KEY_URL
             - track: beta
-            - apk_path: $RELEASE_APK_PATH
-            - app_path: $BITRISE_AAB_PATH
+            - app_path: $RELEASE_APK_PATH
             - package_name: com.mapeo
     meta:
       bitrise.io: null

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -112,7 +112,7 @@ workflows:
                   # Uppercase flavor or remove
                   filename="${filename/-qa-/-QA-}"
                   filename="${filename/-icca-release/-ICCA}"
-                  filename="${filename/-intel-release/-x86}"
+                  filename="${filename/-app-intel/-x86}"
                   filename="${filename/-app-release/}"
                   filename="${filename/-app-/-}"
                   # Construct path with new filename

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -200,7 +200,7 @@ workflows:
             - files_to_upload: $RELEASE_APK_PATH
             - body: "See [changelog](https://github.com/digidem/mapeo-mobile/blob/develop/CHANGELOG.md) for a detailed list of changes"
             - api_token: $GITHUB_TOKEN
-      - google-play-deploy@3.0.2:
+      - google-play-deploy@3.7.2:
           inputs:
             - service_account_json_key_path: $BITRISEIO_SERVICE_ACCOUNT_JSON_KEY_URL
             - track: beta

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -81,7 +81,7 @@ workflows:
     before_run:
       - primary
     envs:
-      - GRADLE_TASKS: assembleApp assembleIccaRelease bundleAppUniversal -x assembleAppDebug
+      - GRADLE_TASKS: assembleApp assembleIccaRelease assembleAppUniversal assembleAppIntel -x assembleAppDebug
         opts:
           is_expand: false
     steps:
@@ -112,6 +112,7 @@ workflows:
                   # Uppercase flavor or remove
                   filename="${filename/-qa-/-QA-}"
                   filename="${filename/-icca-release/-ICCA}"
+                  filename="${filename/-intel-release/-x86}"
                   filename="${filename/-app-release/}"
                   filename="${filename/-app-/-}"
                   # Construct path with new filename
@@ -142,10 +143,12 @@ workflows:
                 RELEASE_APK_PATH=$(echo -n "${BITRISE_APK_PATH_LIST//|/$'\n'}" | grep mapeo-.*[0-9]\.apk)
                 UNIVERSAL_APK_PATH=$(echo -n "${BITRISE_APK_PATH_LIST//|/$'\n'}" | grep mapeo-.*[0-9]-universal\.apk)
                 ICCA_RELEASE_APK_PATH=$(echo -n "${BITRISE_APK_PATH_LIST//|/$'\n'}" | grep mapeo-.*ICCA\.apk)
+                INTEL_RELEASE_APK_PATH=$(echo -n "${BITRISE_APK_PATH_LIST//|/$'\n'}" | grep mapeo-.*x86\.apk)
 
                 envman add --key RELEASE_APK_PATH --value "$RELEASE_APK_PATH"
                 envman add --key UNIVERSAL_APK_PATH --value "$UNIVERSAL_APK_PATH"
                 envman add --key ICCA_RELEASE_APK_PATH --value "$ICCA_RELEASE_APK_PATH"
+                envman add --key INTEL_RELEASE_APK_PATH --value "$INTEL_RELEASE_APK_PATH"
       - amazon-s3-uploader@1.0.1:
           title: Upload APK for Arm
           inputs:
@@ -204,7 +207,7 @@ workflows:
           inputs:
             - service_account_json_key_path: $BITRISEIO_SERVICE_ACCOUNT_JSON_KEY_URL
             - track: beta
-            - app_path: $RELEASE_APK_PATH
+            - app_path: $RELEASE_APK_PATH|$INTEL_RELEASE_APK_PATH
             - package_name: com.mapeo
     meta:
       bitrise.io: null


### PR DESCRIPTION
Currently, for the Play Store release, our Bitrise deployment script uploads an [Android App Bundle](https://developer.android.com/guide/app-bundle) (`.aab`) to the Play Store. When a device installs Mapeo from the Play Store, the store uses this AAB to generate an APK that contains _only_ the architecture (ABI) used by the phone. In most cases this will either be `armeabi-v7a` (32-bit Arm) or `arm64-v8a` (64-bit Arm). The current AAB also includes builds for 64-bit and 32-bit Intel (x86) devices. There are virtually no x86 phones, but Chromebooks now run Android apps and many of those have a x86 processor.

The problem with this current setup is that a 64-bit Arm phone would install an APK that only has the architecture for 64-bit phones. This is good in that the Play Store download is smaller, but it means that the 64-bit phone that installed from the Play Store can _only_ update other 64-bit phones, but it cannot update 32-bit phones. Vice-versa is ok (a 64-bit phone can run a 32-bit APK). This is all quite confusing for users trying to understand why a given phone may or may not update another.

The proposed solution here is to upload an APK to the Play Store (instead of the AAB) that contains Arm 32-bit and Arm 64-bit binaries. The Play Store will not re-package an APK (it will only do that if you upload an AAB). This means that devices that install from the Play Store will now get an APK that contains binaries for both 32-bit and 64-bit architectures, so they can share p2p updates with either 32-bit or 64-bit phones.

I have not included Intel (x86) binaries in this APK, because that would double the size of the APK, increasing download time. Instead I am uploading to the Play Store a separate APK for Intel (x86) which includes both 32-bit and 64-bit binaries for Intel. This means that an Intel device will _not_ be able to p2p update an Arm device. I think this is a reasonable compromise (reducing download size vs. universality of p2p update working).

Play Store should accept both APKs, and send the correct one to the corresponding device (e.g. x86 devices will get the APK with the x86 binaries, and Arm devices will get the APK with arm binaries), but we will not be able to test this until we try to deploy a release.