### PR TITLE
hotfix/v5.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.4.4](https://github.com/digidem/mapeo-mobile/compare/v5.4.3...v5.4.4) (2022-05-03)
+
+### Bug Fixes
+
+- fix p2p-updates startup error ([9da24f7](https://github.com/digidem/mapeo-mobile/commit/9da24f7cbbbec528e2534e075eb5a93192bf61a8))
+- upgrade icons library to fix gradle issue ([9c607a6](https://github.com/digidem/mapeo-mobile/commit/9c607a645570fba3bc4fcf695fb2651d6b3f7b95))
+
 ### [5.4.3](https://github.com/digidem/mapeo-mobile/compare/v5.4.2...v5.4.3) (2022-04-25)
 
 ### Bug Fixes

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,14 +82,19 @@ project.ext.react = [
     // We distribute the QA debug build for testing, so that we get debug logs.
     // This setting bundles the JS into the APK, so you don't need the metro
     // bundler running in order to run the Debug QA build
-    bundleInQaDebug: true,
     bundleInUniversal: true,
+    bundleInIntel: true,
+    bundleInRelease: true,
     enableHermes: false, // clean and rebuild if changing
     // Disable dev logging in the Universal build (only disabled in release
     // build type by default)
     devDisabledInAppUniversal: true,
     devDisabledInQaUniversal: true,
-    devDisabledInIccaUniversal: true
+    devDisabledInIccaUniversal: true,
+    devDisabledInAppIntel: true,
+    devDisabledInQaIntel: true,
+    devDisabledInIccaIntel: true
+
 ]
 
 project.ext.vectoricons = [
@@ -101,7 +106,6 @@ apply from: '../../node_modules/react-native-unimodules/gradle.groovy'
 apply from: "../../node_modules/react-native-vector-icons/fonts.gradle"
 
 // Add bugsnag plugin for source map and symbol uploads
-apply plugin: 'com.android.application'
 apply plugin: 'com.bugsnag.android.gradle'
 
 /**

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -25,7 +25,7 @@ workflows:
     before_run:
       - primary
     envs:
-      - GRADLE_TASKS: assembleIccaRelease assembleAppUniversal assembleAppRelease assembleAppIntel assembleQaRelease
+      - GRADLE_TASKS: assembleAppRelease assembleAppIntel assembleAppUniversal assembleIccaRelease assembleQaRelease -x bundleAppReleaseJsAndAssets -x bundleAppIntelJsAndAssets -x bundleAppUniversalJsAndAssets -x bundleIccaReleaseJsAndAssets -s bundleQaReleaseJsAndAssets
         opts:
           is_expand: false
     steps:
@@ -115,6 +115,7 @@ workflows:
                 node ./scripts/gh-pages-redirect.js /latest https://mapeo-apks.s3.amazonaws.com/release/v${VERSION_NAME}/${RELEASE_APK_PATH##*/}
       - amazon-s3-uploader@1.0.1:
           title: Upload universal (all ABIs) APK
+          is_skippable: true
           inputs:
             - aws_access_key: $AWS_ACCESS_KEY_ID
             - aws_secret_key: $AWS_SECRET_ACCESS_KEY
@@ -123,6 +124,7 @@ workflows:
             - file_path: $UNIVERSAL_APK_PATH
       - amazon-s3-uploader@1.0.1:
           title: Upload APK for ICCA (Arm)
+          is_skippable: true
           inputs:
             - aws_access_key: $AWS_ACCESS_KEY_ID
             - aws_secret_key: $AWS_SECRET_ACCESS_KEY
@@ -131,6 +133,7 @@ workflows:
             - file_path: $ICCA_RELEASE_APK_PATH
       - script@1.1.6:
           title: Update download URL for ICCA
+          is_skippable: true
           inputs:
             - content: |-
                 #!/usr/bin/env bash
@@ -162,7 +165,7 @@ workflows:
     before_run:
       - primary
     envs:
-      - GRADLE_TASKS: assembleQaDebug assembleQaRelease assembleAppRelease assembleIccaRelease
+      - GRADLE_TASKS: assembleAppRelease assembleIccaRelease assembleQaRelease -x bundleAppReleaseJsAndAssets -x bundleIccaReleaseJsAndAssets -s bundleQaReleaseJsAndAssets
         opts:
           is_expand: false
     steps:
@@ -347,6 +350,10 @@ workflows:
                 envman add --key VERSION_NAME --value $VERSION_NAME
                 envman add --key ANDROID_VERSION_NAME --value $ANDROID_VERSION_NAME
                 envman add --key ANDROID_VERSION_CODE --value $BITRISE_BUILD_NUMBER
+      - script-runner@0.9.3:
+          title: Prepare JS bundles
+          inputs:
+            - file_path: scripts/prepare-js-bundles-android.js
       - change-workdir@1.0:
           is_always_run: true
           inputs:
@@ -367,6 +374,25 @@ workflows:
             - is_create_path: "false"
             - path: ..
       - cache-push@2: {}
+      - script@1:
+          title: Check APK assets
+          inputs:
+            - content: |
+                #!/usr/bin/env bash
+                # fail if any commands fails
+                set -e
+                # make pipelines' return status equal the last command to exit with a non-zero status, or zero if all commands exit successfully
+                set -o pipefail
+                # debug log
+                shopt -s extdebug
+
+                # Split the path_list variable by | into an array
+                IFS='|' read -r -a paths <<< "$BITRISE_APK_PATH_LIST"
+
+                for path in "${paths[@]}"
+                do
+                  node scripts/check-apk-assets.js "${path}"
+                done
     meta:
       bitrise.io: null
       stack: linux-docker-android

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -353,6 +353,7 @@ workflows:
       - script-runner@0.9.3:
           title: Prepare JS bundles
           inputs:
+            - runner: /usr/bin/env node
             - file_path: scripts/prepare-js-bundles-android.js
       - change-workdir@1.0:
           is_always_run: true

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -25,7 +25,7 @@ workflows:
     before_run:
       - primary
     envs:
-      - GRADLE_TASKS: assembleAppRelease assembleAppIntel assembleAppUniversal assembleIccaRelease assembleQaRelease -x bundleAppReleaseJsAndAssets -x bundleAppIntelJsAndAssets -x bundleAppUniversalJsAndAssets -x bundleIccaReleaseJsAndAssets -s bundleQaReleaseJsAndAssets
+      - GRADLE_TASKS: assembleAppRelease assembleAppIntel assembleAppUniversal assembleIccaRelease assembleQaRelease -x bundleAppReleaseJsAndAssets -x bundleAppIntelJsAndAssets -x bundleAppUniversalJsAndAssets -x bundleIccaReleaseJsAndAssets -x bundleQaReleaseJsAndAssets
         opts:
           is_expand: false
     steps:
@@ -165,7 +165,7 @@ workflows:
     before_run:
       - primary
     envs:
-      - GRADLE_TASKS: assembleAppRelease assembleIccaRelease assembleQaRelease -x bundleAppReleaseJsAndAssets -x bundleIccaReleaseJsAndAssets -s bundleQaReleaseJsAndAssets
+      - GRADLE_TASKS: assembleAppRelease assembleIccaRelease assembleQaRelease -x bundleAppReleaseJsAndAssets -x bundleIccaReleaseJsAndAssets -x bundleQaReleaseJsAndAssets
         opts:
           is_expand: false
     steps:

--- a/package-lock.json
+++ b/package-lock.json
@@ -5565,11 +5565,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001295",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001295.tgz",
-          "integrity": "sha512-lSP16vcyC0FEy0R4ECc9duSPoKoZy+YkpGkue9G4D81OfPnliopaZrU10+qtPdT8PbGXad/PNx43TIQrOmJZSQ=="
-        },
         "core-js-compat": {
           "version": "3.20.2",
           "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.20.2.tgz",
@@ -14734,10 +14729,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001111",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001111.tgz",
-      "integrity": "sha512-xnDje2wchd/8mlJu8sXvWxOGvMgv+uT3iZ3bkIAynKOzToCssWCmkz/ZIkQBs/2pUB4uwnJKVORWQ31UkbVjOg==",
-      "dev": true
+      "version": "1.0.30001339",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001339.tgz",
+      "integrity": "sha512-Es8PiVqCe+uXdms0Gu5xP5PF2bxLR7OBp3wUzUnuO7OHzhOfCyg3hdiGWVPVxhiuniOzng+hTc1u3fEQ0TlkSQ=="
     },
     "capitalize": {
       "version": "1.0.0",
@@ -32732,11 +32726,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001279",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-          "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
-        },
         "chalk": {
           "version": "4.1.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -33132,11 +33121,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001279",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-          "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
-        },
         "electron-to-chromium": {
           "version": "1.3.893",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
@@ -33407,11 +33391,6 @@
             "node-releases": "^2.0.1",
             "picocolors": "^1.0.0"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001279",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-          "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
         },
         "electron-to-chromium": {
           "version": "1.3.893",
@@ -33853,11 +33832,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001279",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-          "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
-        },
         "electron-to-chromium": {
           "version": "1.3.893",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
@@ -34165,11 +34139,6 @@
             "node-releases": "^2.0.1",
             "picocolors": "^1.0.0"
           }
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001279",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-          "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
         },
         "electron-to-chromium": {
           "version": "1.3.893",
@@ -34775,11 +34744,6 @@
             "picocolors": "^1.0.0"
           }
         },
-        "caniuse-lite": {
-          "version": "1.0.30001279",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-          "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
-        },
         "electron-to-chromium": {
           "version": "1.3.893",
           "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.893.tgz",
@@ -35315,11 +35279,6 @@
           "version": "6.2.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz",
           "integrity": "sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg=="
-        },
-        "caniuse-lite": {
-          "version": "1.0.30001279",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001279.tgz",
-          "integrity": "sha512-VfEHpzHEXj6/CxggTwSFoZBBYGQfQv9Cf42KPlO79sWXCD1QNKWKsKzFeWL7QpZHJQYAvocqV6Rty1yJMkqWLQ=="
         },
         "cliui": {
           "version": "6.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14477,6 +14477,12 @@
       "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
       "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
     },
+    "buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
+    },
     "buffer-fill": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
@@ -20106,6 +20112,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/fbjs-css-vars/-/fbjs-css-vars-1.0.2.tgz",
       "integrity": "sha512-b2XGFAFdWZWg0phtAWLHCk836A1Xann+I+Dgd3Gk64MHKZO44FfoD1KxyvbSh0qZsIoXQGGlVztIY+oitJPpRQ=="
+    },
+    "fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
+      "dev": true,
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "figgy-pudding": {
       "version": "3.5.2",
@@ -37361,6 +37376,12 @@
         "sha.js": "^2.4.8"
       }
     },
+    "pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA=",
+      "dev": true
+    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -43920,6 +43941,16 @@
           "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
           "dev": true
         }
+      }
+    },
+    "yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
+      "dev": true,
+      "requires": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
       }
     },
     "yocto-queue": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapeo-mobile",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11634,7 +11634,8 @@
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+      "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
     },
     "@types/debug": {
       "version": "4.1.7",
@@ -39348,37 +39349,35 @@
       }
     },
     "react-native-vector-icons": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-7.0.0.tgz",
-      "integrity": "sha512-Ku8+dTUAnR9pexRPQqsUcQEZlxEpFZsIy8iOFqVL/3mrUyncZJHtqJyx2cUOmltZIC6W2GI4IkD3EYzPerXV5g==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/react-native-vector-icons/-/react-native-vector-icons-9.1.0.tgz",
+      "integrity": "sha512-2AHZ/h9d/+rC0odz+OwbGNlc1Lik/pHhSixn4HfC8RtQ8CxfSBZ6gg7bTLcZhdSvZN+ZEGi30Fj+ZnOSQy+smg==",
       "requires": {
-        "lodash": "^4.17.15",
         "prop-types": "^15.7.2",
-        "yargs": "^15.0.2"
+        "yargs": "^16.1.1"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
         },
         "ansi-styles": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-          "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "requires": {
-            "@types/color-name": "^1.1.1",
             "color-convert": "^2.0.1"
           }
         },
         "cliui": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-          "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
           "requires": {
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.0",
-            "wrap-ansi": "^6.2.0"
+            "wrap-ansi": "^7.0.0"
           }
         },
         "color-convert": {
@@ -39399,65 +39398,67 @@
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
           "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
         },
+        "escalade": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+          "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
-            "strip-ansi": "^6.0.0"
+            "strip-ansi": "^6.0.1"
           }
         },
         "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+          "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-regex": "^5.0.1"
           }
         },
         "wrap-ansi": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-          "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
           "requires": {
             "ansi-styles": "^4.0.0",
             "string-width": "^4.1.0",
             "strip-ansi": "^6.0.0"
           }
         },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
+        },
         "yargs": {
-          "version": "15.4.1",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-          "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
           "requires": {
-            "cliui": "^6.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^4.1.0",
-            "get-caller-file": "^2.0.1",
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
             "require-directory": "^2.1.1",
-            "require-main-filename": "^2.0.0",
-            "set-blocking": "^2.0.0",
             "string-width": "^4.2.0",
-            "which-module": "^2.0.0",
-            "y18n": "^4.0.0",
-            "yargs-parser": "^18.1.2"
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
           }
         },
         "yargs-parser": {
-          "version": "18.1.3",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-          "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+          "version": "20.2.9",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+          "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -187,7 +187,8 @@
     "rimraf": "^3.0.0",
     "standard-version": "^8.0.2",
     "ts-jest": "^27.0.3",
-    "txtgen": "^2.2.7"
+    "txtgen": "^2.2.7",
+    "yauzl": "^2.10.0"
   },
   "standard-version": {
     "skip": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "react-native-tab-view": "^2.15.1",
     "react-native-unimodules": "^0.14.10",
     "react-native-v8": "^0.66.3-patch.1",
-    "react-native-vector-icons": "^7.0.0",
+    "react-native-vector-icons": "^9.1.0",
     "react-navigation": "^4.4.0",
     "react-navigation-hooks": "^1.0.1",
     "react-navigation-stack": "^2.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapeo-mobile",
-  "version": "5.4.3",
+  "version": "5.4.4",
   "private": true,
   "engines": {
     "node": "12.16.3"

--- a/scripts/check-apk-assets.js
+++ b/scripts/check-apk-assets.js
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+
+const yauzl = require("yauzl");
+const path = require("path");
+
+const [apkPath] = process.argv.slice(2);
+
+// Array of regexes or strings to match against file paths in APK
+// File paths should *NOT* start with a `/`, and are relative to the root of the APK
+const checkList = [
+  "assets/index.android.bundle",
+  "assets/fonts/MaterialCommunityIcons.ttf",
+  "assets/fonts/FontAwesome.ttf",
+  "assets/fonts/MaterialIcons.ttf",
+  "assets/fonts/Octicons.ttf",
+];
+
+yauzl.open(apkPath, { autoClose: false }, (err, zipfile) => {
+  if (err) throw err;
+  const checked = new Array(checkList.length).fill(false);
+  zipfile.on("entry", entry => {
+    for (const [i, check] of checkList.entries()) {
+      if (
+        typeof check === "string"
+          ? check === entry.fileName
+          : check.test(entry.fileName)
+      ) {
+        checked[i] = true;
+      }
+    }
+  });
+  zipfile.on("error", err => {
+    console.error(`Error reading '${path.basename(apkPath)}':`, err);
+    process.exit(1);
+  });
+  zipfile.on("end", () => {
+    if (checked.every(Boolean)) {
+      console.log(`'${path.basename(apkPath)}' is valid`);
+      process.exit(0);
+    } else {
+      const missing = checkList.filter((_, i) => !checked[i]);
+      console.error(
+        `'${path.basename(apkPath)}' is missing files:\n  -`,
+        missing.map(regex => regex.toString()).join("\n  - ")
+      );
+      process.exit(1);
+    }
+  });
+});

--- a/scripts/check-output-apks.sh
+++ b/scripts/check-output-apks.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+set -eEu -o pipefail
+shopt -s extdebug
+IFS=$'\n\t'
+trap 'onFailure $?' ERR
+
+function onFailure() {
+  echo "Unhandled script error $1 at ${BASH_SOURCE[0]}:${BASH_LINENO[0]}" >&2
+  exit 1
+}
+
+# Ensure we start in the right place
+dir0="$( cd "$( dirname "$0" )" && pwd )"
+repo_root="$(dirname "$dir0")"
+apk_dir="$repo_root/android/app/build/outputs/apk"
+apk_files="$( find "$apk_dir" -name "*.apk" )"
+
+for apk in $apk_files; do
+  node "${dir0}/check-apk-assets.js" "$apk"
+done

--- a/scripts/prepare-js-bundles-android.js
+++ b/scripts/prepare-js-bundles-android.js
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+
+const path = require("path");
+const fs = require("fs-extra");
+const mkdirp = require("mkdirp");
+const { promisify } = require("util");
+const exec = promisify(require("child_process").exec);
+
+const bundleAssetName = "index.android.bundle";
+const projectRoot = path.resolve(__dirname, "..");
+const androidDir = path.join(projectRoot, "android");
+const buildDir = path.join(androidDir, "app/build");
+const jsBundleRoot = path.join(buildDir, "generated/assets/react/");
+const resourcesRoot = path.join(buildDir, "generated/res/react/");
+const jsSourceMapsRoot = path.join(buildDir, "generated/sourcemaps/react");
+
+const flavors = ["app", "icca", "qa"];
+const buildTypes = ["release", "intel", "universal"];
+
+(async () => {
+  // First of all, make sure all the destination directories exist
+  const createDirsPromises = [];
+  for (const flavor of flavors) {
+    for (const buildType of buildTypes) {
+      createDirsPromises.push([
+        mkdirp(path.join(jsBundleRoot, flavor, buildType)),
+        mkdirp(path.join(resourcesRoot, flavor, buildType)),
+        mkdirp(path.join(jsSourceMapsRoot, flavor, buildType)),
+      ]);
+    }
+  }
+  await Promise.all(createDirsPromises);
+  console.log("Created directories for bundle output");
+
+  // The react native gradle build script creates a separate JavaScript bundle
+  // for each flavor and build type combination. For Mapeo Mobile all bundles
+  // are the same except for the `icca` flavor, which includes the ICCA specific
+  // code. We generate bundles for the `app` and `icca` flavors and then copy
+  // bundles and resources across for the other variants, so we avoid the extra
+  // build time of generating all the extra bundles
+  for (const flavor of ["app", "icca"]) {
+    const targetPath = `${flavor}/release/`;
+    const jsBundleDir = path.join(jsBundleRoot, targetPath);
+    const jsBundleFile = path.join(jsBundleDir, bundleAssetName);
+    const resourcesDir = path.join(resourcesRoot, targetPath);
+    const jsSourceMapsDir = path.join(jsSourceMapsRoot, targetPath);
+    const jsOutputSourceMapFile = path.join(
+      jsSourceMapsDir,
+      bundleAssetName + ".map"
+    );
+
+    console.log(`Generating bundle for '${flavor}' flavor`);
+    const {
+      stdout,
+    } = await exec(
+      `RN_SRC_EXT=${flavor} react-native bundle --platform android --dev false --reset-cache --entry-file index.js --bundle-output ${jsBundleFile} --sourcemap-output ${jsOutputSourceMapFile} --assets-dest ${resourcesDir}`,
+      { cwd: projectRoot }
+    );
+    console.log(stdout);
+    console.log(`Created bundle for '${flavor}' flavor`);
+  }
+  console.log("Bundle generation complete");
+
+  // Copy across the app and icca flavor bundles to all the other
+  // flavor/buildType variants
+  const copyPromises = [];
+  for (const flavor of flavors) {
+    for (const buildType of buildTypes) {
+      if (flavor === "icca" && buildType === "release") continue;
+      if (flavor === "app" && buildType === "release") continue;
+      const sourcePath = flavor === "icca" ? "icca/release" : "app/release";
+      const targetPath = `${flavor}/${buildType}`;
+      copyPromises.push([
+        fs.copy(
+          path.join(jsBundleRoot, sourcePath, bundleAssetName),
+          path.join(jsBundleRoot, targetPath, bundleAssetName)
+        ),
+        fs.copy(
+          path.join(jsSourceMapsRoot, sourcePath, bundleAssetName + ".map"),
+          path.join(jsSourceMapsRoot, targetPath, bundleAssetName + ".map")
+        ),
+        fs.copy(
+          path.join(resourcesRoot, sourcePath),
+          path.join(resourcesRoot, targetPath)
+        ),
+      ]);
+    }
+  }
+  await Promise.all(copyPromises);
+  console.log("Bundle copy complete");
+
+  // Run gradle tasks to copy the bundled Js and Assets into the correct
+  // folders, but skip the bundle tasks (because we already generated our
+  // bundles above)
+  console.log("Running gradle copyBundledJs tasks");
+  const gradleTasks = [];
+  const gradleExcludeTasks = [];
+  for (const flavor of flavors) {
+    for (const buildType of buildTypes) {
+      // We ignore this variant in our build.gradle, so need to skip it here
+      if (flavor === "qa" && buildType === "universal") continue;
+      const variantName = `${capitalize(flavor)}${capitalize(buildType)}`;
+      gradleTasks.push(`copy${variantName}BundledJs`);
+      gradleExcludeTasks.push(`-x bundle${variantName}JsAndAssets`);
+    }
+  }
+  const gradleCommand = [...gradleTasks, ...gradleExcludeTasks].join(" ");
+  const { stdout } = await exec(`./gradlew ${gradleCommand}`, {
+    cwd: androidDir,
+  });
+  console.log(stdout);
+  console.log("Gradle copyBundledJs tasks complete");
+})();
+
+function capitalize(str) {
+  return str.charAt(0).toUpperCase() + str.slice(1);
+}

--- a/scripts/prepare-js-bundles-android.js
+++ b/scripts/prepare-js-bundles-android.js
@@ -53,7 +53,7 @@ const buildTypes = ["release", "intel", "universal"];
     const {
       stdout,
     } = await exec(
-      `RN_SRC_EXT=${flavor} react-native bundle --platform android --dev false --reset-cache --entry-file index.js --bundle-output ${jsBundleFile} --sourcemap-output ${jsOutputSourceMapFile} --assets-dest ${resourcesDir}`,
+      `RN_SRC_EXT=${flavor} npx react-native bundle --platform android --dev false --reset-cache --entry-file index.js --bundle-output ${jsBundleFile} --sourcemap-output ${jsOutputSourceMapFile} --assets-dest ${resourcesDir}`,
       { cwd: projectRoot }
     );
     console.log(stdout);

--- a/src/backend/.npmrc
+++ b/src/backend/.npmrc
@@ -1,1 +1,3 @@
 package-lock=true
+# Make `npm ci` work on CI see https://github.com/ds300/patch-package/issues/185
+unsafe-perm=true


### PR DESCRIPTION
p2p updates is not working in v5.4.3. This is happened because we switched our build machines from MacOS to Linux, which means that `npm install` is running as root user (UID 0) instead of UID 501 on MacOS. When npm is running as root it will not run `postinstall` scripts, so the patch-package was not being run. This caused a reversion to an error that caused the p2p update server to fail to start.
