### PR TITLE
chore: simplify nodejs startup & fix bugsnag

### DIFF
--- a/__mocks__/nodejs-mobile-react-native.js
+++ b/__mocks__/nodejs-mobile-react-native.js
@@ -5,4 +5,5 @@ export default {
   channel: Object.assign(new EventEmitter(), {
     post: jest.fn(),
   }),
+  startWithArgs: jest.fn(),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -37245,12 +37245,17 @@
         "which": "1"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+        },
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.6"
           }
         },
         "rimraf": {
@@ -37269,9 +37274,9 @@
       }
     },
     "nodejs-mobile-react-native": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/nodejs-mobile-react-native/-/nodejs-mobile-react-native-0.6.3.tgz",
-      "integrity": "sha512-En4bR2Kj8pidIvm8gGN+9PY/haj6FlU+9Pmh3qPDVyjGSjXjz4QWNN8/8565aFKE7cHxJjYWTptnrdJwL5r94g==",
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/nodejs-mobile-react-native/-/nodejs-mobile-react-native-0.8.1.tgz",
+      "integrity": "sha512-Erj6EI0UHYvAmPM3GcGKXRV3mKaRTW7LZFfyr1QyNCr00A6iX9IHj67YSks3EuOgeDoJsLc1B4EFxNInI3/YUA==",
       "requires": {
         "mkdirp": "^0.5.1",
         "ncp": "^2.0.0",
@@ -37279,12 +37284,17 @@
         "xcode": "^2.0.0"
       },
       "dependencies": {
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+        },
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.6"
           }
         }
       }
@@ -42653,12 +42663,17 @@
           "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
           "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
+        "minimist": {
+          "version": "1.2.6",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+          "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+        },
         "mkdirp": {
-          "version": "0.5.5",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+          "version": "0.5.6",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+          "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
           "requires": {
-            "minimist": "^1.2.5"
+            "minimist": "^1.2.6"
           }
         },
         "safe-buffer": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint *.js \"src/**/*.js\"",
     "flow": "flow",
     "flow-typed": "flow-typed install -i dev",
-    "log": "adb logcat -v brief *:S NODEJS-MOBILE:V ReactNative:V ReactNativeJS:V",
+    "log": "adb logcat -v brief *:S NODEJS-MOBILE:V nodejs:V ReactNative:V ReactNativeJS:V",
     "dev-menu": "adb shell input keyevent 82",
     "prettier": "prettier --write \"src/**/*.js\"",
     "prettier:staged": "pretty-quick --staged",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "lodash": "^4.17.19",
     "mapeo-offline-map": "^2.0.0",
     "mapeo-schema": "^2.0.2",
-    "nodejs-mobile-react-native": "^0.6.3",
+    "nodejs-mobile-react-native": "^0.8.1",
     "p-is-promise": "^4.0.0",
     "p-timeout": "^4.1.0",
     "patch-package": "^6.4.7",

--- a/patches/nodejs-mobile-react-native+0.8.1.patch
+++ b/patches/nodejs-mobile-react-native+0.8.1.patch
@@ -19,7 +19,7 @@ index 337de9b..636ef2b 100644
    private final ReactApplicationContext reactContext;
    private static final String TAG = "NODEJS-RN";
    private static final String NODEJS_PROJECT_DIR = "nodejs-project";
-+  private static final String NODEJS_ASSETS_DIR = "nodejs-assets"
++  private static final String NODEJS_ASSETS_DIR = "nodejs-assets";
    private static final String NODEJS_BUILTIN_MODULES = "nodejs-builtin_modules";
    private static final String TRASH_DIR = "nodejs-project-trash";
    private static final String SHARED_PREFS = "NODEJS_MOBILE_PREFS";

--- a/patches/nodejs-mobile-react-native+0.8.1.patch
+++ b/patches/nodejs-mobile-react-native+0.8.1.patch
@@ -1,33 +1,10 @@
 diff --git a/node_modules/nodejs-mobile-react-native/android/build.gradle b/node_modules/nodejs-mobile-react-native/android/build.gradle
-index e54f25c..79b96e2 100644
+index a80f197..c77e439 100644
 --- a/node_modules/nodejs-mobile-react-native/android/build.gradle
 +++ b/node_modules/nodejs-mobile-react-native/android/build.gradle
-@@ -50,6 +50,7 @@ def _isCorrectSTLDefinedByApp = DoesAppAlreadyDefineWantedSTL()
- android {
-     compileSdkVersion ((rootProject?.ext?.properties?.compileSdkVersion) ?: 23)
-     buildToolsVersion ((rootProject?.ext?.properties?.buildToolsVersion) ?: "23.0.1")
-+    ndkVersion "21.4.7075529"
- 
-     defaultConfig {
-         minSdkVersion _nodeMinSdkVersion
-@@ -76,9 +77,11 @@ android {
-     }
- 
-     sourceSets {
--        main {
--            jniLibs.srcDirs 'libnode/bin/'
--        }
-+        // Not needed
-+        // see https://github.com/JaneaSystems/nodejs-mobile/issues/317#issuecomment-852033823
-+        // main {
-+        //     jniLibs.srcDirs 'libnode/bin/'
-+        // }
-         main.assets.srcDirs += '../install/resources/nodejs-modules'
-     }
- 
-@@ -239,7 +242,7 @@ if ("1".equals(shouldRebuildNativeModules)) {
+@@ -238,7 +238,7 @@ if ("1".equals(shouldRebuildNativeModules)) {
      GenerateNodeProjectAssetsLists.dependsOn "ApplyPatchScriptToModules"
- 
+
      def nativeModulesABIs = android.defaultConfig.ndk.abiFilters;
 -    if (nativeModulesABIs == null) {
 +    if (!nativeModulesABIs) {
@@ -35,14 +12,14 @@ index e54f25c..79b96e2 100644
          nativeModulesABIs = ["armeabi-v7a", "x86", "arm64-v8a", "x86_64"] as Set<String>;
      }
 diff --git a/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java b/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java
-index e882a0c..d5ed11a 100644
+index 337de9b..636ef2b 100644
 --- a/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java
 +++ b/node_modules/nodejs-mobile-react-native/android/src/main/java/com/janeasystems/rn_nodejs_mobile/RNNodeJsMobileModule.java
 @@ -32,6 +32,7 @@ public class RNNodeJsMobileModule extends ReactContextBaseJavaModule implements
    private final ReactApplicationContext reactContext;
    private static final String TAG = "NODEJS-RN";
    private static final String NODEJS_PROJECT_DIR = "nodejs-project";
-+  private static final String NODEJS_ASSETS_DIR = "nodejs-assets";
++  private static final String NODEJS_ASSETS_DIR = "nodejs-assets"
    private static final String NODEJS_BUILTIN_MODULES = "nodejs-builtin_modules";
    private static final String TRASH_DIR = "nodejs-project-trash";
    private static final String SHARED_PREFS = "NODEJS_MOBILE_PREFS";
@@ -53,19 +30,19 @@ index e882a0c..d5ed11a 100644
 +  private static String nodeJsAssetsPath;
    private static String builtinModulesPath;
    private static String nativeAssetsPath;
- 
+
 @@ -74,6 +76,7 @@ public class RNNodeJsMobileModule extends ReactContextBaseJavaModule implements
- 
+
      // The paths where we expect the node project assets to be at runtime.
      nodeJsProjectPath = filesDirPath + "/" + NODEJS_PROJECT_DIR;
 +    nodeJsAssetsPath = filesDirPath + "/" + NODEJS_ASSETS_DIR;
      builtinModulesPath = filesDirPath + "/" + NODEJS_BUILTIN_MODULES;
      trashDirPath = filesDirPath + "/" + TRASH_DIR;
      nativeAssetsPath = BUILTIN_NATIVE_ASSETS_PREFIX + getCurrentABIName();
-@@ -387,6 +390,9 @@ public class RNNodeJsMobileModule extends ReactContextBaseJavaModule implements
+@@ -424,6 +427,9 @@ public class RNNodeJsMobileModule extends ReactContextBaseJavaModule implements
      // Copy the nodejs built-in modules to the application's data path.
      copyAssetFolder("builtin_modules", builtinModulesPath);
- 
+
 +    // Copy nodejs assets (e.g. presets) which can vary between variants
 +    copyAssetFolder("nodejs-assets", nodeJsAssetsPath);
 +

--- a/src/backend/app.js
+++ b/src/backend/app.js
@@ -1,0 +1,176 @@
+/*!
+ * Mapeo Mobile is an Android app for offline participatory mapping.
+ *
+ * Copyright (C) 2017 Digital Democracy
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+// @ts-check
+const rnBridge = require("rn-bridge");
+const debug = require("debug");
+
+const ServerStatus = require("./status");
+const constants = require("./constants");
+const createServer = require("./server");
+const { getInstallerInfo } = require("./upgrade-manager/utils");
+const Bugsnag = require("@bugsnag/js").default;
+const semverPrerelease = require("semver/functions/prerelease");
+
+const log = debug("mapeo-core:index");
+const PORT = 9081;
+const BUGSNAG_API_KEY = "c7f8a8d9e9c9f0b0f9e8e8d9a7f8a8d9";
+
+module.exports = init;
+
+/** @param {import('../shared-types').ServerStartupConfig} config */
+async function init(config) {
+  const {
+    bundleId,
+    version,
+    isDev,
+    sharedStorage,
+    privateCacheStorage,
+    supportedAbis,
+    sdkVersion,
+    apkFilepath,
+  } = config;
+
+  const variant = bundleId.endsWith("icca") ? "icca" : "mapeo";
+  const releaseStage =
+    isDev || bundleId.endsWith("debug")
+      ? "development"
+      : parseReleaseStage(version);
+  // Don't debug log in production
+  if (releaseStage !== "production") debug.enable("*");
+  log("config", arguments[0]);
+
+  Bugsnag.start({
+    apiKey: BUGSNAG_API_KEY,
+    releaseStage,
+    appVersion: version,
+    enabledReleaseStages: ["production", "rc", "internal"],
+    appType: "android_node",
+    metadata: { variant },
+    onUncaughtException: error => {
+      log("uncaughtException", error);
+      status &&
+        status.setState(constants.ERROR, {
+          error,
+          context: "uncaughtException",
+        });
+    },
+    onUnhandledRejection: error => {
+      log("unhandledRejection", error);
+      status &&
+        status.setState(constants.ERROR, {
+          error,
+          context: "unhandledRejection",
+        });
+    },
+  });
+
+  const status = new ServerStatus();
+  status.startHeartbeat();
+
+  try {
+    const currentApkInfo = await getInstallerInfo(apkFilepath);
+    const server = createServer({
+      privateStorage: rnBridge.app.datadir(),
+      sharedStorage,
+      privateCacheStorage,
+      deviceInfo: { supportedAbis, sdkVersion },
+      currentApkInfo,
+    });
+    server.on("error", error => {
+      status.setState(constants.ERROR, { error, context: "server" });
+    });
+    startServer();
+
+    /**
+     * Close the server and pause heartbeat when in background
+     * We need to do this because otherwise Android/iOS may shutdown the node
+     * process when it sees it is doing things in the background
+     */
+    rnBridge.app.on(
+      "pause",
+      /** @param {any} pauseLock */ pauseLock => {
+        log("App went into background");
+        status.pauseHeartbeat();
+        stopServer(() => pauseLock.release());
+      }
+    );
+
+    // Start things up again when app is back in foreground
+    rnBridge.app.on("resume", () => {
+      log("App went into foreground");
+      // When the RN app requests permissions from the user it causes a resume event
+      // but no pause event. We don't need to start the server if it's already
+      // listening (because it wasn't paused)
+      // https://github.com/janeasystems/nodejs-mobile/issues/177
+      status.startHeartbeat();
+      startServer();
+    });
+
+    // eslint-disable-next-line no-inner-declarations
+    function startServer() {
+      const state = status.getState();
+      if (state === constants.CLOSING) {
+        log("Server was closing when it tried to start");
+        server.on("close", () => startServer());
+      } else if (state === constants.IDLE || state === constants.CLOSED) {
+        status.setState(constants.STARTING);
+        server.listen(PORT, () => {
+          status.setState(constants.LISTENING);
+        });
+      } else {
+        log("tried to start server but state was: " + state);
+      }
+    }
+
+    const noop = () => {};
+
+    // eslint-disable-next-line no-inner-declarations
+    function stopServer(cb = noop) {
+      if (!server) return process.nextTick(cb);
+      const state = status.getState();
+      if (state === constants.STARTING) {
+        log("Server was starting when it tried to close");
+        server.on("listening", () => stopServer(cb));
+      } else if (state !== constants.IDLE) {
+        status.setState(constants.CLOSING);
+        server.close(() => {
+          status.setState(constants.CLOSED);
+          cb();
+        });
+      } else {
+        process.nextTick(cb);
+      }
+    }
+  } catch (error) {
+    console.log(error.stack);
+    status.setState(constants.ERROR, { error, context: "createServer" });
+  }
+}
+
+/**
+ * @param {string} version
+ * @returns {'production' | 'rc' | 'internal'}
+ */
+function parseReleaseStage(version) {
+  const prereleaseComponents = semverPrerelease(version);
+  if (!prereleaseComponents) return "production";
+  if (prereleaseComponents[0] === "rc") return "rc";
+  return "internal";
+}

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -16,7 +16,8 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+// @ts-check
+// @ts-ignore
 const rnBridge = require("rn-bridge");
 const debug = require("debug");
 
@@ -24,154 +25,152 @@ const ServerStatus = require("./status");
 const constants = require("./constants");
 const createServer = require("./server");
 const { getInstallerInfo } = require("./upgrade-manager/utils");
-const createBugsnag = require("@bugsnag/js");
+const Bugsnag = require("@bugsnag/js").default;
 const semverPrerelease = require("semver/functions/prerelease");
-const { version } = require("../../package.json");
-
-const prereleaseComponents = semverPrerelease(version);
-const releaseStage = prereleaseComponents
-  ? prereleaseComponents[0]
-  : "production";
 
 const log = debug("mapeo-core:index");
 const PORT = 9081;
-const status = new ServerStatus();
-let server;
+const BUGSNAG_API_KEY = "c7f8a8d9e9c9f0b0f9e8e8d9a7f8a8d9";
 
-// This is nastily circular: we need an instance of status for the constructor
-// of bugsnag (so that we can inform the front-end of errors) but then we need
-// the instance of bugsnag for other modules (which are required above, when
-// module.exports.bugsnag is still undefined)
-const bugsnag = createBugsnag({
-  apiKey: "572d472ea9d5a9199777b88ef268da4e",
-  releaseStage: releaseStage,
-  appVersion: version,
-  appType: "server",
-  onUncaughtException: error => {
-    log("uncaughtException", error);
-    status && status.setState(constants.ERROR, { error });
-  },
-  onUnhandledRejection: error => {
-    log("unhandledRejection", error);
-    status && status.setState(constants.ERROR, { error });
-  },
-});
+module.exports = init;
 
-module.exports.bugsnag = bugsnag;
+/** @param {import('../shared-types').ServerStartupConfig} config */
+async function init(config) {
+  const {
+    bundleId,
+    version,
+    isDev,
+    sharedStorage,
+    privateCacheStorage,
+    supportedAbis,
+    sdkVersion,
+    apkFilepath,
+  } = config;
 
-status.startHeartbeat();
+  const variant = bundleId.endsWith("icca") ? "icca" : "mapeo";
+  const releaseStage =
+    isDev || bundleId.endsWith("debug")
+      ? "development"
+      : parseReleaseStage(version);
+  // Don't debug log in production
+  if (releaseStage !== "production") debug.enable("*");
+  log("config", arguments[0]);
 
-/**
- * We use a user folder on external storage for some data (custom map styles and
- * presets). "External Storage" on Android does not actually mean an external SD
- * card. It is a shared folder that the user can access. The data folder
- * accessible through rnBridge.app.datadir() is not accessible by the user.
- *
- * Other config data such as the path to the APK file is only available in the
- * React Native process, so we pass that to the backend here
- *
- * We need to wait for the React Native process to tell us where the folder is.
- */
-rnBridge.channel.once("config", async config => {
-  log("config", config);
-  if (server) {
-    const error = new Error(
-      "Server already existed when config event was received"
-    );
-    status.setState(constants.ERROR, { error, context: "config" });
-    return;
-  }
+  Bugsnag.start({
+    apiKey: BUGSNAG_API_KEY,
+    releaseStage,
+    appVersion: version,
+    enabledReleaseStages: ["production", "rc", "internal"],
+    appType: "android_node",
+    metadata: { variant },
+    onUncaughtException: error => {
+      log("uncaughtException", error);
+      status &&
+        status.setState(constants.ERROR, {
+          error,
+          context: "uncaughtException",
+        });
+    },
+    onUnhandledRejection: error => {
+      log("unhandledRejection", error);
+      status &&
+        status.setState(constants.ERROR, {
+          error,
+          context: "unhandledRejection",
+        });
+    },
+  });
+
+  const status = new ServerStatus();
+  status.startHeartbeat();
+
   try {
-    const {
-      sharedStorage,
-      privateCacheStorage,
-      deviceInfo,
-      apkFilepath,
-      isDev,
-    } = config;
-    // Don't debug log in production
-    if (isDev) debug.enable("*");
     const currentApkInfo = await getInstallerInfo(apkFilepath);
-    server = createServer({
+    const server = createServer({
       privateStorage: rnBridge.app.datadir(),
       sharedStorage,
       privateCacheStorage,
-      deviceInfo,
+      deviceInfo: { supportedAbis, sdkVersion },
       currentApkInfo,
     });
     server.on("error", error => {
-      status.setState(constants.ERROR, { error });
+      status.setState(constants.ERROR, { error, context: "server" });
     });
     startServer();
+
+    /**
+     * Close the server and pause heartbeat when in background
+     * We need to do this because otherwise Android/iOS may shutdown the node
+     * process when it sees it is doing things in the background
+     */
+    rnBridge.app.on(
+      "pause",
+      /** @param {any} pauseLock */ pauseLock => {
+        log("App went into background");
+        status.pauseHeartbeat();
+        stopServer(() => pauseLock.release());
+      }
+    );
+
+    // Start things up again when app is back in foreground
+    rnBridge.app.on("resume", () => {
+      log("App went into foreground");
+      // When the RN app requests permissions from the user it causes a resume event
+      // but no pause event. We don't need to start the server if it's already
+      // listening (because it wasn't paused)
+      // https://github.com/janeasystems/nodejs-mobile/issues/177
+      status.startHeartbeat();
+      startServer();
+    });
+
+    // eslint-disable-next-line no-inner-declarations
+    function startServer() {
+      const state = status.getState();
+      if (state === constants.CLOSING) {
+        log("Server was closing when it tried to start");
+        server.on("close", () => startServer());
+      } else if (state === constants.IDLE || state === constants.CLOSED) {
+        status.setState(constants.STARTING);
+        server.listen(PORT, () => {
+          status.setState(constants.LISTENING);
+        });
+      } else {
+        log("tried to start server but state was: " + state);
+      }
+    }
+
+    const noop = () => {};
+
+    // eslint-disable-next-line no-inner-declarations
+    function stopServer(cb = noop) {
+      if (!server) return process.nextTick(cb);
+      const state = status.getState();
+      if (state === constants.STARTING) {
+        log("Server was starting when it tried to close");
+        server.on("listening", () => stopServer(cb));
+      } else if (state !== constants.IDLE) {
+        status.setState(constants.CLOSING);
+        server.close(() => {
+          status.setState(constants.CLOSED);
+          cb();
+        });
+      } else {
+        process.nextTick(cb);
+      }
+    }
   } catch (error) {
     console.log(error.stack);
     status.setState(constants.ERROR, { error, context: "createServer" });
   }
-});
-
-/**
- * Close the server and pause heartbeat when in background
- * We need to do this because otherwise Android/iOS may shutdown the node
- * process when it sees it is doing things in the background
- */
-rnBridge.app.on("pause", pauseLock => {
-  log("App went into background");
-  status.pauseHeartbeat();
-  stopServer(() => pauseLock.release());
-});
-
-// Start things up again when app is back in foreground
-rnBridge.app.on("resume", () => {
-  log("App went into foreground");
-  // When the RN app requests permissions from the user it causes a resume event
-  // but no pause event. We don't need to start the server if it's already
-  // listening (because it wasn't paused)
-  // https://github.com/janeasystems/nodejs-mobile/issues/177
-  status.startHeartbeat();
-
-  // (achou11): this check is not ideal but necessary because of how the 'resume' event
-  // is spawned after interacting with RN's permissions prompt on startup.
-  // It seems to be inconsistent based on OS, RN, and/or nodejs-mobile-react-native versions
-  if (server) {
-    startServer();
-  }
-});
-
-const noop = () => {};
-
-function startServer() {
-  if (!server) {
-    const error = new Error("Tried to start server before config was received");
-    status.setState(constants.ERROR, { error, context: "createServer" });
-    return;
-  }
-  const state = status.getState();
-  if (state === constants.CLOSING) {
-    log("Server was closing when it tried to start");
-    server.on("close", () => startServer());
-  } else if (state === constants.IDLE || state === constants.CLOSED) {
-    status.setState(constants.STARTING);
-    server.listen(PORT, () => {
-      status.setState(constants.LISTENING);
-    });
-  } else {
-    log("tried to start server but state was: " + state);
-  }
 }
 
-function stopServer(cb = noop) {
-  if (!server) return process.nextTick(cb);
-  const state = status.getState();
-  if (state === constants.STARTING) {
-    log("Server was starting when it tried to close");
-    server.on("listening", () => stopServer(cb));
-  } else if (state !== constants.IDLE) {
-    status.setState(constants.CLOSING);
-    server.close(() => {
-      status.setState(constants.CLOSED);
-      cb();
-    });
-  } else {
-    process.nextTick(cb);
-  }
+/**
+ * @param {string} version
+ * @returns {'production' | 'rc' | 'internal'}
+ */
+function parseReleaseStage(version) {
+  const prereleaseComponents = semverPrerelease(version);
+  if (!prereleaseComponents) return "production";
+  if (prereleaseComponents[0] === "rc") return "rc";
+  return "internal";
 }

--- a/src/backend/index.js
+++ b/src/backend/index.js
@@ -1,176 +1,88 @@
-/*!
- * Mapeo Mobile is an Android app for offline participatory mapping.
- *
- * Copyright (C) 2017 Digital Democracy
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
 // @ts-check
-// @ts-ignore
-const rnBridge = require("rn-bridge");
-const debug = require("debug");
+const minimist = require("minimist");
+const init = require("./app");
 
-const ServerStatus = require("./status");
-const constants = require("./constants");
-const createServer = require("./server");
-const { getInstallerInfo } = require("./upgrade-manager/utils");
-const Bugsnag = require("@bugsnag/js").default;
-const semverPrerelease = require("semver/functions/prerelease");
+/** @typedef {import('../shared-types').ServerStartupConfig} Config */
+/**
+ * @template T
+ * @typedef {Array<keyof import('type-fest').ConditionalPick<Config, T>>} ConfigArray
+ */
 
-const log = debug("mapeo-core:index");
-const PORT = 9081;
-const BUGSNAG_API_KEY = "c7f8a8d9e9c9f0b0f9e8e8d9a7f8a8d9";
+/** @type {ConfigArray<string>} */
+const stringConfigOptions = [
+  "sharedStorage",
+  "privateCacheStorage",
+  "apkFilepath",
+  "buildNumber",
+  "bundleId",
+  "version",
+];
+/** @type {ConfigArray<string[]>} */
+const stringArrayConfigOptions = ["supportedAbis"];
+/** @type {ConfigArray<boolean>} */
+const booleanConfigOptions = ["isDev"];
+/** @type {ConfigArray<number>} */
+const numberConfigOptions = ["sdkVersion"];
 
-module.exports = init;
+try {
+  const config = parseArgs();
+  init(config);
+} catch (e) {
+  console.log("Server startup error:", e);
+}
 
-/** @param {import('../shared-types').ServerStartupConfig} config */
-async function init(config) {
-  const {
-    bundleId,
-    version,
-    isDev,
-    sharedStorage,
-    privateCacheStorage,
-    supportedAbis,
-    sdkVersion,
-    apkFilepath,
-  } = config;
-
-  const variant = bundleId.endsWith("icca") ? "icca" : "mapeo";
-  const releaseStage =
-    isDev || bundleId.endsWith("debug")
-      ? "development"
-      : parseReleaseStage(version);
-  // Don't debug log in production
-  if (releaseStage !== "production") debug.enable("*");
-  log("config", arguments[0]);
-
-  Bugsnag.start({
-    apiKey: BUGSNAG_API_KEY,
-    releaseStage,
-    appVersion: version,
-    enabledReleaseStages: ["production", "rc", "internal"],
-    appType: "android_node",
-    metadata: { variant },
-    onUncaughtException: error => {
-      log("uncaughtException", error);
-      status &&
-        status.setState(constants.ERROR, {
-          error,
-          context: "uncaughtException",
-        });
+function parseArgs() {
+  /** @type {minimist.Opts} */
+  const minimistOptions = {
+    string: [...stringConfigOptions, ...stringArrayConfigOptions],
+    boolean: booleanConfigOptions,
+    unknown: arg => {
+      const parsedArg = arg.split("=")[0].replace(/^-{1,2}/, "");
+      // @ts-ignore
+      if (numberConfigOptions.includes(parsedArg)) return true;
+      else throw new Error("Unknown server startup argument: " + parsedArg);
     },
-    onUnhandledRejection: error => {
-      log("unhandledRejection", error);
-      status &&
-        status.setState(constants.ERROR, {
-          error,
-          context: "unhandledRejection",
-        });
-    },
-  });
+  };
 
-  const status = new ServerStatus();
-  status.startHeartbeat();
-
-  try {
-    const currentApkInfo = await getInstallerInfo(apkFilepath);
-    const server = createServer({
-      privateStorage: rnBridge.app.datadir(),
-      sharedStorage,
-      privateCacheStorage,
-      deviceInfo: { supportedAbis, sdkVersion },
-      currentApkInfo,
-    });
-    server.on("error", error => {
-      status.setState(constants.ERROR, { error, context: "server" });
-    });
-    startServer();
-
-    /**
-     * Close the server and pause heartbeat when in background
-     * We need to do this because otherwise Android/iOS may shutdown the node
-     * process when it sees it is doing things in the background
-     */
-    rnBridge.app.on(
-      "pause",
-      /** @param {any} pauseLock */ pauseLock => {
-        log("App went into background");
-        status.pauseHeartbeat();
-        stopServer(() => pauseLock.release());
-      }
-    );
-
-    // Start things up again when app is back in foreground
-    rnBridge.app.on("resume", () => {
-      log("App went into foreground");
-      // When the RN app requests permissions from the user it causes a resume event
-      // but no pause event. We don't need to start the server if it's already
-      // listening (because it wasn't paused)
-      // https://github.com/janeasystems/nodejs-mobile/issues/177
-      status.startHeartbeat();
-      startServer();
-    });
-
-    // eslint-disable-next-line no-inner-declarations
-    function startServer() {
-      const state = status.getState();
-      if (state === constants.CLOSING) {
-        log("Server was closing when it tried to start");
-        server.on("close", () => startServer());
-      } else if (state === constants.IDLE || state === constants.CLOSED) {
-        status.setState(constants.STARTING);
-        server.listen(PORT, () => {
-          status.setState(constants.LISTENING);
-        });
-      } else {
-        log("tried to start server but state was: " + state);
-      }
-    }
-
-    const noop = () => {};
-
-    // eslint-disable-next-line no-inner-declarations
-    function stopServer(cb = noop) {
-      if (!server) return process.nextTick(cb);
-      const state = status.getState();
-      if (state === constants.STARTING) {
-        log("Server was starting when it tried to close");
-        server.on("listening", () => stopServer(cb));
-      } else if (state !== constants.IDLE) {
-        status.setState(constants.CLOSING);
-        server.close(() => {
-          status.setState(constants.CLOSED);
-          cb();
-        });
-      } else {
-        process.nextTick(cb);
-      }
-    }
-  } catch (error) {
-    console.log(error.stack);
-    status.setState(constants.ERROR, { error, context: "createServer" });
+  const { _, "--": __, ...argv } = minimist(
+    process.argv.slice(2),
+    minimistOptions
+  );
+  for (const arg of stringArrayConfigOptions) {
+    if (!argv[arg]) throw new Error(`Missing required argument: ${arg}`);
+    argv[arg] = argv[arg].split(",");
   }
+  validateArgs(argv);
+  return argv;
 }
 
 /**
- * @param {string} version
- * @returns {'production' | 'rc' | 'internal'}
+ * @param {{ [key: string]: unknown }} args
+ * @returns {asserts args is Config}
  */
-function parseReleaseStage(version) {
-  const prereleaseComponents = semverPrerelease(version);
-  if (!prereleaseComponents) return "production";
-  if (prereleaseComponents[0] === "rc") return "rc";
-  return "internal";
+function validateArgs(args) {
+  for (const arg of stringConfigOptions) {
+    if (typeof args[arg] !== "string")
+      throw new Error(
+        `Expected ${arg} to be a string, got ${typeof args[arg]}`
+      );
+  }
+  for (const arg of stringArrayConfigOptions) {
+    if (!Array.isArray(args[arg]))
+      throw new Error(
+        `Expected ${arg} to be an array, got ${typeof args[arg]}`
+      );
+  }
+  for (const arg of booleanConfigOptions) {
+    if (typeof args[arg] !== "boolean")
+      throw new Error(
+        `Expected ${arg} to be a boolean, got ${typeof args[arg]}`
+      );
+  }
+  for (const arg of numberConfigOptions) {
+    if (typeof args[arg] !== "number")
+      throw new Error(
+        `Expected ${arg} to be a number, got ${typeof args[arg]}`
+      );
+  }
 }

--- a/src/backend/loader.js
+++ b/src/backend/loader.js
@@ -1,10 +1,78 @@
+// @ts-check
 const os = require("os");
 const path = require("path");
+// @ts-ignore
 const rnBridge = require("rn-bridge");
+const minimist = require("minimist");
+const init = require("./index");
+
+/** @typedef {import('../shared-types').ServerStartupConfig} ServerStartupConfig */
+/** @type {Array<keyof import('type-fest').ConditionalPick<ServerStartupConfig, string>>} */
+const stringConfigOptions = [
+  "sharedStorage",
+  "privateCacheStorage",
+  "apkFilepath",
+  "buildNumber",
+  "bundleId",
+  "version",
+];
+/** @type {Array<keyof import('type-fest').ConditionalPick<ServerStartupConfig, string[]>>} */
+const stringArrayConfigOptions = ["supportedAbis"];
+/** @type {Array<keyof import('type-fest').ConditionalPick<ServerStartupConfig, boolean>>} */
+const booleanConfigOptions = ["isDev"];
+/** @type {Array<keyof import('type-fest').ConditionalPick<ServerStartupConfig, number>>} */
+const numberConfigOptions = ["sdkVersion"];
+
+const config = parseArgs();
 
 const nodejsProjectDir = path.resolve(rnBridge.app.datadir(), "nodejs-project");
 os.homedir = () => nodejsProjectDir;
 process.cwd = () => nodejsProjectDir;
 process.env = process.env || {};
 process.env.CHLORIDE_JS = "yes"; // Use WebAssembly libsodium
-require("./index");
+
+init(config);
+
+function parseArgs() {
+  /** @type {minimist.Opts} */
+  const minimistOptions = {
+    string: [...stringConfigOptions, ...stringArrayConfigOptions],
+    boolean: booleanConfigOptions,
+    unknown: arg => {
+      // @ts-ignore
+      if (numberConfigOptions.includes(arg)) return true;
+      else throw new Error("Unknown server startup argument: " + arg);
+    },
+  };
+
+  const { _, ...argv } = minimist(process.argv.slice(2), minimistOptions);
+  for (const arg of stringArrayConfigOptions) {
+    if (!argv[arg]) throw new Error(`Missing required argument: ${arg}`);
+    argv[arg] = argv[arg].split(",");
+  }
+  validateArgs(argv);
+  return argv;
+}
+
+/**
+ * @param {{ [key: string]: unknown }} args
+ * @returns {asserts args is ServerStartupConfig}
+ */
+function validateArgs(args) {
+  for (const arg of stringConfigOptions) {
+    if (typeof args[arg] !== "string")
+      throw new Error(`Missing required argument: ${arg}`);
+  }
+  for (const arg of stringArrayConfigOptions) {
+    if (!Array.isArray(args[arg]))
+      throw new Error(`Missing required argument: ${arg}`);
+  }
+  for (const arg of booleanConfigOptions) {
+    if (typeof args[arg] !== "boolean")
+      throw new Error(`Missing required argument: ${arg}`);
+  }
+  for (const arg of numberConfigOptions) {
+    if (typeof args[arg] === "number")
+      throw new Error(`Missing required argument: ${arg}`);
+  }
+}

--- a/src/backend/loader.js
+++ b/src/backend/loader.js
@@ -1,29 +1,12 @@
 // @ts-check
+
+// This file sets up some global variables that are incorrectly set in
+// nodejs-mobile, e.g. the cwd points to root ("/") on mobile, so we override it
+// with the nodejs project dir
+
 const os = require("os");
 const path = require("path");
-// @ts-ignore
 const rnBridge = require("rn-bridge");
-const minimist = require("minimist");
-const init = require("./index");
-
-/** @typedef {import('../shared-types').ServerStartupConfig} ServerStartupConfig */
-/** @type {Array<keyof import('type-fest').ConditionalPick<ServerStartupConfig, string>>} */
-const stringConfigOptions = [
-  "sharedStorage",
-  "privateCacheStorage",
-  "apkFilepath",
-  "buildNumber",
-  "bundleId",
-  "version",
-];
-/** @type {Array<keyof import('type-fest').ConditionalPick<ServerStartupConfig, string[]>>} */
-const stringArrayConfigOptions = ["supportedAbis"];
-/** @type {Array<keyof import('type-fest').ConditionalPick<ServerStartupConfig, boolean>>} */
-const booleanConfigOptions = ["isDev"];
-/** @type {Array<keyof import('type-fest').ConditionalPick<ServerStartupConfig, number>>} */
-const numberConfigOptions = ["sdkVersion"];
-
-const config = parseArgs();
 
 const nodejsProjectDir = path.resolve(rnBridge.app.datadir(), "nodejs-project");
 os.homedir = () => nodejsProjectDir;
@@ -31,48 +14,4 @@ process.cwd = () => nodejsProjectDir;
 process.env = process.env || {};
 process.env.CHLORIDE_JS = "yes"; // Use WebAssembly libsodium
 
-init(config);
-
-function parseArgs() {
-  /** @type {minimist.Opts} */
-  const minimistOptions = {
-    string: [...stringConfigOptions, ...stringArrayConfigOptions],
-    boolean: booleanConfigOptions,
-    unknown: arg => {
-      // @ts-ignore
-      if (numberConfigOptions.includes(arg)) return true;
-      else throw new Error("Unknown server startup argument: " + arg);
-    },
-  };
-
-  const { _, ...argv } = minimist(process.argv.slice(2), minimistOptions);
-  for (const arg of stringArrayConfigOptions) {
-    if (!argv[arg]) throw new Error(`Missing required argument: ${arg}`);
-    argv[arg] = argv[arg].split(",");
-  }
-  validateArgs(argv);
-  return argv;
-}
-
-/**
- * @param {{ [key: string]: unknown }} args
- * @returns {asserts args is ServerStartupConfig}
- */
-function validateArgs(args) {
-  for (const arg of stringConfigOptions) {
-    if (typeof args[arg] !== "string")
-      throw new Error(`Missing required argument: ${arg}`);
-  }
-  for (const arg of stringArrayConfigOptions) {
-    if (!Array.isArray(args[arg]))
-      throw new Error(`Missing required argument: ${arg}`);
-  }
-  for (const arg of booleanConfigOptions) {
-    if (typeof args[arg] !== "boolean")
-      throw new Error(`Missing required argument: ${arg}`);
-  }
-  for (const arg of numberConfigOptions) {
-    if (typeof args[arg] === "number")
-      throw new Error(`Missing required argument: ${arg}`);
-  }
-}
+require("./index");

--- a/src/backend/package-lock.json
+++ b/src/backend/package-lock.json
@@ -44,30 +44,56 @@
       }
     },
     "@bugsnag/browser": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-6.5.2.tgz",
-      "integrity": "sha512-XFKKorJc92ivLnlHHhLiPvkP03tZ5y7n0Z2xO6lOU7t+jWF5YapgwqQAda/TWvyYO38B/baWdnOpWMB3QmjhkA=="
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@bugsnag/browser/-/browser-7.16.5.tgz",
+      "integrity": "sha512-EftyLRfUgQL/7leHhlfL756KlcBsG8C7wwMRRoyzGnAIH0Uu/l1RfBi5Tf1Fhk+LOwkDedTxDtQOa70EC8oS8A==",
+      "requires": {
+        "@bugsnag/core": "^7.16.1"
+      }
+    },
+    "@bugsnag/core": {
+      "version": "7.16.1",
+      "resolved": "https://registry.npmjs.org/@bugsnag/core/-/core-7.16.1.tgz",
+      "integrity": "sha512-zuBnL7B329VldItRqhXYrp1hjmjZnltJwNXMysi9WtY4t29WKk5LVwgWb1mPM9clJ0FoObZ7kvvQMUTKh3ezFQ==",
+      "requires": {
+        "@bugsnag/cuid": "^3.0.0",
+        "@bugsnag/safe-json-stringify": "^6.0.0",
+        "error-stack-parser": "^2.0.3",
+        "iserror": "0.0.2",
+        "stack-generator": "^2.0.3"
+      }
+    },
+    "@bugsnag/cuid": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/cuid/-/cuid-3.0.0.tgz",
+      "integrity": "sha512-LOt8aaBI+KvOQGneBtpuCz3YqzyEAehd1f3nC5yr9TIYW1+IzYKa2xWS4EiMz5pPOnRPHkyyS5t/wmSmN51Gjg=="
     },
     "@bugsnag/js": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-6.5.2.tgz",
-      "integrity": "sha512-4ibw624fM5+Y/WSuo3T/MsJVtslsPV8X0MxFuRxdvpKVUXX216d8hN8E/bG4hr7aipqQOGhBYDqSzeL2wgmh0Q==",
+      "version": "7.16.5",
+      "resolved": "https://registry.npmjs.org/@bugsnag/js/-/js-7.16.5.tgz",
+      "integrity": "sha512-IzFkRRhisAdfAG5ihKbd9c2YtBmYWuA3Yw+KnzwVwQ/dDZKpWMPzQOv9uVznA1u8Dqv9347e/uUbRzudlGUJog==",
       "requires": {
-        "@bugsnag/browser": "^6.5.2",
-        "@bugsnag/node": "^6.5.2"
+        "@bugsnag/browser": "^7.16.5",
+        "@bugsnag/node": "^7.16.2"
       }
     },
     "@bugsnag/node": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-6.5.2.tgz",
-      "integrity": "sha512-KQ1twKoOttMCYsHv7OXUVsommVcrk6RGQ5YoZGlTbREhccbzsvjbiXPKiY31Qc7OXKvaJwSXhnOKrQTpRleFUg==",
+      "version": "7.16.2",
+      "resolved": "https://registry.npmjs.org/@bugsnag/node/-/node-7.16.2.tgz",
+      "integrity": "sha512-V5pND701cIYGzjjTwt0tuvAU1YyPB9h7vo5F/DzrDHRPmCINA/oVbc0Twco87knc2VPe8ntGFqTicTY65iOWzg==",
       "requires": {
+        "@bugsnag/core": "^7.16.1",
         "byline": "^5.0.0",
         "error-stack-parser": "^2.0.2",
         "iserror": "^0.0.2",
         "pump": "^3.0.0",
         "stack-generator": "^2.0.3"
       }
+    },
+    "@bugsnag/safe-json-stringify": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@bugsnag/safe-json-stringify/-/safe-json-stringify-6.0.0.tgz",
+      "integrity": "sha512-htzFO1Zc57S8kgdRK9mLcPVTW1BY2ijfH7Dk2CeZmspTWKdKqSo1iwmqrq2WtRjFlo8aRZYgLX0wFrDXF/9DLA=="
     },
     "@digidem/atomic-fs-blob-store": {
       "version": "5.3.1",
@@ -1376,7 +1402,7 @@
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-      "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
+      "integrity": "sha512-s6webAy+R4SR8XVuJWt2V2rGvhnrhxN+9S15GNuTK3wKPOXFF6RNc+8ug2XhH+2s4f+uudG4kUVYmYOQWL2g0Q=="
     },
     "bytebuffer": {
       "version": "5.0.1",
@@ -2261,9 +2287,9 @@
       }
     },
     "error-stack-parser": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.6.tgz",
-      "integrity": "sha512-d51brTeqC+BHlwF0BhPtcYgF5nlzf9ZZ0ZIUQNZpc9ZB9qw5IJ2diTrBY9jlCJkTLITYPjmiX6OWCwH+fuyNgQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.0.7.tgz",
+      "integrity": "sha512-chLOW0ZGRf4s8raLrDxa5sdkvPec5YdvwbFnqJme4rk0rFajP8mPtrDL1+I+CwrQDCjswDA5sREX7jYQDQs9vA==",
       "requires": {
         "stackframe": "^1.1.1"
       }
@@ -4699,9 +4725,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mixin-deep": {
       "version": "1.3.2",
@@ -6628,9 +6654,9 @@
       }
     },
     "stackframe": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.0.tgz",
-      "integrity": "sha512-GrdeshiRmS1YLMYgzF16olf2jJ/IzxXY9lhKOskuVziubpTYcYqyOwYeJKzQkwy7uN0fYSsbsC4RQaXf9LCrYA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.2.1.tgz",
+      "integrity": "sha512-h88QkzREN/hy8eRdyNhhsO7RSJ5oyTqxxmmn0dzBIMUclZsjpfmrsg81vp8mjjAs2vAZ72nyWxRUwSwmh0e4xg=="
     },
     "static-extend": {
       "version": "0.1.2",
@@ -7115,9 +7141,9 @@
       }
     },
     "type-fest": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.1.3.tgz",
-      "integrity": "sha512-CsiQeFMR1jZEq8R+H59qe+bBevnjoV5N2WZTTdlyqxeoODQOOepN2+msQOywcieDq5sBjabKzTn3U+sfHZlMdw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "dev": true
     },
     "type-name": {

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -15,7 +15,7 @@
   "author": "Digital Democracy",
   "license": "MIT",
   "dependencies": {
-    "@bugsnag/js": "^6.3.1",
+    "@bugsnag/js": "^7.16.5",
     "@gmaclennan/zip-fs": "^1.2.0",
     "@mapeo/map-server": "^1.0.0-alpha.4",
     "@sinclair/typebox": "^0.16.5",
@@ -38,6 +38,7 @@
     "mapeo-config-icca": "^1.4.0",
     "mapeo-default-settings": "^3.6.1",
     "mapeo-server": "^17.1.0",
+    "minimist": "^1.2.6",
     "mkdirp": "^1.0.4",
     "network-address": "^1.1.2",
     "p-defer": "^3.0.0",
@@ -82,7 +83,7 @@
     "through2": "^4.0.2",
     "tmp": "^0.2.1",
     "tmp-promise": "^3.0.2",
-    "type-fest": "^1.1.3",
+    "type-fest": "^1.4.0",
     "typescript": "^4.2.4"
   }
 }

--- a/src/backend/status.js
+++ b/src/backend/status.js
@@ -1,7 +1,7 @@
 const rnBridge = require("rn-bridge");
 const log = require("debug")("mapeo-core:status");
+const Bugsnag = require("@bugsnag/js").default;
 const constants = require("./constants");
-const main = require("./index");
 
 class ServerStatus {
   constructor() {
@@ -34,7 +34,9 @@ class ServerStatus {
     if (nextState === constants.ERROR) {
       error = error || new Error("Unknown server error");
       log(context, error.message);
-      main.bugsnag.notify(error, { context });
+      Bugsnag.notify(error, event => {
+        event.context = context;
+      });
     }
     this.state = nextState;
     rnBridge.channel.post("status", {

--- a/src/backend/types/rn-bridge.d.ts
+++ b/src/backend/types/rn-bridge.d.ts
@@ -1,0 +1,21 @@
+declare module "rn-bridge" {
+  interface Channel {
+    on(event: string, callback: (message: any) => void): void;
+    post(event: string, message: any): void;
+    send(message: any): void;
+  }
+  interface App {
+    on(
+      event: "pause",
+      callback: (pauseLock: { release: () => void }) => void
+    ): void;
+    on(event: "resume", callback: () => void): void;
+    datadir(): string;
+  }
+  interface RNBridge {
+    channel: Channel;
+    app: App;
+  }
+  const rnBridge: RNBridge;
+  export = rnBridge;
+}

--- a/src/frontend/api.ts
+++ b/src/frontend/api.ts
@@ -446,7 +446,7 @@ export function Api({ baseUrl, timeout = DEFAULT_TIMEOUT }: ApiParam) {
         privateCacheStorage: RNFS.CachesDirectoryPath,
         apkFilepath: AppInfo.sourceDir,
         sdkVersion: await DeviceInfo.getApiLevel(),
-        supportedAbis: await DeviceInfo.supportedAbis(),
+        supportedAbis: (await DeviceInfo.supportedAbis()) as ServerStartupConfig["supportedAbis"],
         version: DeviceInfo.getVersion(),
         buildNumber: DeviceInfo.getBuildNumber(),
         bundleId: DeviceInfo.getBundleId(),
@@ -454,7 +454,7 @@ export function Api({ baseUrl, timeout = DEFAULT_TIMEOUT }: ApiParam) {
       };
       let nodejsCommand = "loader.js";
       for (const [key, value] of Object.entries(config)) {
-        nodejsCommand += ` --${key} ${value}`;
+        nodejsCommand += ` --${key}=${value}`;
       }
       nodejs.startWithArgs(nodejsCommand);
       const serverStartPromise = new Promise<void>(resolve => {

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -3,7 +3,7 @@ export interface ServerStartupConfig {
   privateCacheStorage: string;
   apkFilepath: string;
   sdkVersion: number;
-  supportedAbis: string[];
+  supportedAbis: Array<"x86" | "x86_64" | "armeabi-v7a" | "arm64-v8a">;
   version: string;
   buildNumber: string;
   bundleId: string;

--- a/src/shared-types.ts
+++ b/src/shared-types.ts
@@ -1,0 +1,11 @@
+export interface ServerStartupConfig {
+  sharedStorage: string;
+  privateCacheStorage: string;
+  apkFilepath: string;
+  sdkVersion: number;
+  supportedAbis: string[];
+  version: string;
+  buildNumber: string;
+  bundleId: string;
+  isDev: boolean;
+}


### PR DESCRIPTION
The backend requires values that are only available in the React Native process (storage folders, app version etc.)

Currently the nodejs process waits on an IPC message from RN containing the config before starting. This makes the server startup more complicated and it introduces edge cases for when the app might pause and resume before the server actually starts.

This PR fixes this with the new `nodejs.startWithArgs()` method in nodejs-mobile-react-native@0.8.1. This allows us to pass all the config arguments at the node process startup.

This PR also fixes the bugsnag config for the backend, which previously incorrectly reported the app version (it used the version in package.json, which is only correct for production releases).