### PR TITLE
fix: use correct icon names in sync screen

### DIFF
--- a/src/frontend/sharedComponents/icons/index.js
+++ b/src/frontend/sharedComponents/icons/index.js
@@ -40,7 +40,7 @@ export const CellphoneIcon = ({
 }: FontIconProps) => (
   <MaterialCommunityIcon
     color={color}
-    name="cellphone-android"
+    name="cellphone"
     size={size}
     style={style}
   />
@@ -53,7 +53,7 @@ export const LaptopIcon = ({
 }: FontIconProps) => (
   <MaterialCommunityIcon
     color={color}
-    name="laptop-windows"
+    name="laptop"
     size={size}
     style={style}
   />


### PR DESCRIPTION
Upgrading `react-native-vector-icons` in https://github.com/digidem/mapeo-mobile/pull/963 upgraded the bundled version of MaterialCommunityIcons used to 6.5.95 ([changelog](https://github.com/oblador/react-native-vector-icons/releases/tag/v9.1.0)). A couple of the icons used from this collection (`cellphone-android` and `laptop-windows`) were removed in 6.1.95 (see [changelog](https://dev.materialdesignicons.com/changelog#version-6.1.95)), which affects the sync screen and causes a failure to properly render the appropriate icons for the list of peers.

As recommended by the changelog, this PR updates the associated icon names to use the variation without the platform suffix

<img width="200" alt="image" src="https://user-images.githubusercontent.com/18542095/173607366-253292cf-9249-4425-b1d3-7306c30f7535.png">
