### PR TITLE
chore: Add Discord link to README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,10 +126,7 @@ If you would like your language added to the translations list, [please request 
 
 Connect with the Mapeo community for support & to contribute!
 
-- [**Mailing List**](https://lists.riseup.net/www/info/mapeo-en) (English)
-- [**Mailing List**](https://lists.riseup.net/www/info/mapeo-es) (Spanish)
-- [**IRC**](https://kiwiirc.com/nextclient/irc.freenode.net/) (channel #ddem)
-- [**Slack**](http://slack.digital-democracy.org)
+- [**Discord**](https://discord.gg/KWRFDh3v73)
 
 ## Contributing
 


### PR DESCRIPTION
This is a quick PR just replacing the outdated `Community` links with Discord.