### PR TITLE
chore: fix default background color for navigation screen content

### DIFF
--- a/src/frontend/Navigation/AppStack.tsx
+++ b/src/frontend/Navigation/AppStack.tsx
@@ -5,6 +5,7 @@ import {
   HeaderButtonProps,
   NativeStackNavigationOptions,
 } from "@react-navigation/native-stack/lib/typescript/src/types";
+import { WHITE } from "../lib/styles";
 import { IccaStackList } from "../screens/Intro";
 import { OnboardingStackList } from "./ScreenGroups/Onboarding";
 import { AppList } from "./ScreenGroups/AppScreens";
@@ -23,7 +24,8 @@ export const RootStack = createNativeStackNavigator<AppStackList>();
 
 export const NavigatorScreenOptions: NativeStackNavigationOptions = {
   presentation: "card",
-  headerStyle: { backgroundColor: "#ffffff" },
+  contentStyle: { backgroundColor: WHITE },
+  headerStyle: { backgroundColor: WHITE },
   headerLeft: (props: HeaderButtonProps) => (
     <CustomHeaderLeft headerBackButtonProps={props} />
   ),


### PR DESCRIPTION
Fixes a regression caused by https://github.com/digidem/mapeo-mobile/pull/992/files#diff-3fe14a68ca2c8f88a4ef1e4dcef629f5b7d0f42115bb9f5936fd766b802e7982L140-L142 where the default background color for the screen is a light grey instead of white.

Using `chore` for commit title since the regression isn't yet published, so in theory this fix should not show up in the changelog when we do so

Preview:

- Before:

  <img width="200" alt="image" src="https://user-images.githubusercontent.com/18542095/199327413-57ed68c8-00cf-4840-80b3-10266c2e20e9.png">

  <img width="200" alt="image" src="https://user-images.githubusercontent.com/18542095/199327592-10c0e89c-2e61-480c-8113-3f54f5bdd35d.png">

- After:
  
  <img width="200" alt="image" src="https://user-images.githubusercontent.com/18542095/199327949-8d378d65-8e6b-46b5-96c7-276f97f61cf6.png">

  <img width="200" alt="image" src="https://user-images.githubusercontent.com/18542095/199327849-e9290003-1016-47ae-8cc2-4cfd52dd98e3.png">
