### PR TITLE
chore: Build-time warning if language name is missing

### DIFF
--- a/scripts/build-intl-polyfills.js
+++ b/scripts/build-intl-polyfills.js
@@ -24,12 +24,6 @@ function buildIntlRelativeTimeFormat() {
 
     const hasTranslatedLanguageName = !!languages[locale];
 
-    if (!hasTranslatedLanguageName) {
-      console.warn(
-        `Locale "${locale}" is not available in Mapeo because we do not have a language name and translations in \`src/frontend/languages.json\``
-      );
-    }
-
     return hasAtLeastOneTranslatedString && hasTranslatedLanguageName;
   });
 

--- a/scripts/build-translations.js
+++ b/scripts/build-translations.js
@@ -6,6 +6,7 @@ const mkdirp = require("mkdirp");
 const rimraf = require("rimraf");
 const path = require("path");
 const fs = require("fs");
+const languageNameTranslations = require("../src/frontend/languages.json");
 
 const readFile = util.promisify(fs.readFile);
 const writeFile = util.promisify(fs.writeFile);
@@ -22,16 +23,25 @@ async function writeJson(file, data) {
 rimraf.sync("translations/*");
 
 // "shared" strings are included in translations for all components
-glob("messages/**/*.json", async function(er, files) {
+glob("messages/**/*.json", async function (er, files) {
   const allMsgs = {};
   for (const file of files) {
     const lang = path.parse(file).name;
     const msgs = await readJson(file);
+    // If a language is added to Crowdin, but has no translated messages,
+    // Crowdin still creates an empty file, so we just ignore it
+    if (Object.keys(msgs).length === 0) continue;
     if (!allMsgs[lang]) allMsgs[lang] = msgs;
     else allMsgs[lang] = { ...allMsgs[lang], ...msgs };
   }
   const translations = {};
   for (const lang in allMsgs) {
+    if (!languageNameTranslations[lang]) {
+      console.warn(`Locale '${lang}' has no language name defined in \`src/frontend/languages.json\`,
+so it will not appear as a language option in Mapeo.
+Add the language name in English and the native langague to \`languages.json\`
+in order to allow users to select '${lang}' in Mapeo`);
+    }
     translations[lang] = {};
     const msgs = allMsgs[lang];
     Object.keys(msgs).forEach(key => {


### PR DESCRIPTION
We use [`src/frontend/languages.json`](https://github.com/digidem/mapeo-mobile/blob/develop/src/frontend/languages.json) for displaying English and localized language names in the "Select language" menu of Mapeo. If we don't have a language name, then the language will not appear as an option.

This fix adds a built-time warning for missing language names when translated languages exist for a locale. The fix is to add an English name and localized name for the language to  [`src/frontend/languages.json`](https://github.com/digidem/mapeo-mobile/blob/develop/src/frontend/languages.json)