### PR TITLE
chore: convert IntlContext to Typescript

### DIFF
--- a/src/frontend/context/IntlContext.tsx
+++ b/src/frontend/context/IntlContext.tsx
@@ -1,4 +1,3 @@
-// @flow
 import * as React from "react";
 import { Platform } from "react-native";
 import { IntlProvider as IntlProviderOrig } from "react-intl";
@@ -24,13 +23,18 @@ export const formats = {
   },
 };
 
-type SupportedLanguages = Array<{|
-  locale: string,
-  nativeName: string,
-  englishName: string,
-|}>;
+interface LanguageName {
+  /** IETF BCP 47 langauge tag with region code. */
+  locale: string;
+  /** Localized name for language */
+  nativeName: string;
+  /** English name for language */
+  englishName: string;
+}
 
-export const supportedLanguages: SupportedLanguages = Object.keys(messages)
+const translatedLocales = Object.keys(messages) as Array<keyof typeof messages>;
+
+export const supportedLanguages: LanguageName[] = translatedLocales
   .filter(locale => {
     const hasAtLeastOneTranslatedString =
       Object.keys(messages[locale]).length > 0;

--- a/src/frontend/languages.json
+++ b/src/frontend/languages.json
@@ -479,6 +479,10 @@
     "nativeName": "Lèmbörgs",
     "englishName": "Limburgish"
   },
+  "lo": {
+    "nativeName": "ພາສາລາວ",
+    "englishName": "Lao"
+  },
   "lt": {
     "nativeName": "Lietuvių",
     "englishName": "Lithuanian"
@@ -498,6 +502,10 @@
   "mai": {
     "nativeName": "मैथिली, মৈথিলী",
     "englishName": "Maithili"
+  },
+  "mg": {
+    "nativeName": "Malagasy",
+    "englishName": "Malagasy"
   },
   "mg-MG": {
     "nativeName": "Malagasy",


### PR DESCRIPTION
Convert IntlContext to Typescript

Another step towards bye bye Flow...

Also adds missing language names to languages.json, since the typing caught these as missing.