### PR TITLE
fix: upgrade android target sdk to fulfill google play store requirements

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -15,7 +15,7 @@ task:
     NODEJS_MOBILE_BUILD_NATIVE_MODULES: "0"
     MAPBOX_DOWNLOAD_TOKEN: ENCRYPTED[6c72ef68629d29a9a0d9aa396d1f55badda203ce2d2ce0e21c6f79d6714dc2966db4326efb73d0f6e2082cdf27943d34]
   container:
-    image: digidem/docker-android
+    image: digidem/docker-android:2
     cpu: 8
     memory: 24G
   node_modules_cache:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,8 @@ able to control the mobile app.
 
 ### Pre-requisites
 
+Follow the [official React Native instructions](https://reactnative.dev/docs/0.67/environment-setup) for setting up the majority of what's needed for your development environment (ignore the "Creating a new application" section and anything that comes after it).
+
 In order to develop the full app you will need the Android SDK installed and
 specifically [21.4.7075529 of the NDK](https://developer.android.com/ndk/guides/) in order to build
 nodejs-mobile for Android.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -350,12 +350,6 @@ android {
         exclude 'META-INF/LICENSE.txt'
         exclude 'META-INF/NOTICE.txt'
     }
-
-    // Use Java 11, which is required when Android Target SDK is 31 (Android 12)
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
-    }
 }
 
 dependencies {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -351,10 +351,10 @@ android {
         exclude 'META-INF/NOTICE.txt'
     }
 
-    // Use Java 1.8
+    // Use Java 11, which is required when Android Target SDK is 31 (Android 12)
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 }
 

--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -6,6 +6,6 @@
         android:usesCleartextTraffic="true"
         tools:targetApi="28"
         tools:ignore="GoogleAppIndexingWarning">
-        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" />
+        <activity android:name="com.facebook.react.devsupport.DevSettingsActivity" android:exported="false"/>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -43,7 +43,8 @@
       android:launchMode="singleTask"
       android:largeHeap="true"
       android:screenOrientation="portrait"
-      android:windowSoftInputMode="adjustResize">
+      android:windowSoftInputMode="adjustResize"
+      android:exported="true">
       <intent-filter android:label="filter_react_native">
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,6 +36,13 @@ loadDotEnv()
 
 buildscript {
     ext {
+        // TODO: Ideally this would be 31 but that requires upgrading Gradle to v7+ and would require – at a minimum – the following changes:
+        // 
+        // - upgrading com.android.tools.build:gradle and gradle wrapper to v7+
+        // - upgrading com.bugsnag:bugsnag-android-gradle-plugin to v7
+        // - upgrading various (maybe all?) Expo modules (https://github.com/expo/expo/issues/12774)
+        // 
+        // As detailed in https://github.com/invertase/notifee/pull/217, this version works with v4.2 and v7+ of com.android.tools.build:gradle
         buildToolsVersion = "30.0.3"
         // Android 5.0 - requirement for expo unimodules
         minSdkVersion = 21

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,7 +36,7 @@ loadDotEnv()
 
 buildscript {
     ext {
-        buildToolsVersion = "31.0.0"
+        buildToolsVersion = "30.0.3"
         // Android 5.0 - requirement for expo unimodules
         minSdkVersion = 21
         compileSdkVersion = 31
@@ -45,6 +45,33 @@ buildscript {
         // Kotlin is needed by Detox testing framework and react-native-screens
         kotlinVersion = "1.6.10"
         ndkVersion = "21.4.7075529"
+
+        // All of this (i.e. rnmbglMapboxLibs and rnmbglMapboxPlugins) is needed because of an 
+        // issue with the telemetry module on Android 12 that the default android sdk depends on:
+        // 
+        // https://github.com/rnmapbox/maps/issues/1677
+        // 
+        // Upgrading just the telemetry module based on the provided instructions did not work and
+        // instead I opted to copy the example listed in instructions:
+        // 
+        // https://github.com/rnmapbox/maps/blob/8.5.0/android/install.md#mapbox-maps-sdk-pre-v10
+        // 
+        // The main change that fixes the issue is upgrading the Android SDK to 9.7.2,
+        // which internally uses a version of the telemetry module that works on Android 12:
+        // 
+        // https://github.com/mapbox/mapbox-gl-native-android/releases/tag/android-v9.6.2
+        rnmbglMapboxLibs = {
+            implementation 'com.mapbox.mapboxsdk:mapbox-android-sdk:9.7.2'
+            implementation 'com.mapbox.mapboxsdk:mapbox-sdk-services:5.8.0'
+            implementation 'com.mapbox.mapboxsdk:mapbox-sdk-turf:5.8.0'
+            implementation 'com.mapbox.mapboxsdk:mapbox-android-gestures:0.7.0'
+        }
+
+        rnmbglMapboxPlugins = {
+            implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-annotation-v9:0.8.0'
+            implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-localization-v9:0.14.0'
+            implementation 'com.mapbox.mapboxsdk:mapbox-android-plugin-markerview-v9:0.4.0'
+        }
     }
     repositories {
         google()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,12 +36,12 @@ loadDotEnv()
 
 buildscript {
     ext {
-        buildToolsVersion = "30.0.2"
+        buildToolsVersion = "31.0.0"
         // Android 5.0 - requirement for expo unimodules
         minSdkVersion = 21
-        compileSdkVersion = 30
-        targetSdkVersion = 30
-        supportLibVersion = "30.0.0"
+        compileSdkVersion = 31
+        targetSdkVersion = 31
+        supportLibVersion = "31.0.0"
         // Kotlin is needed by Detox testing framework and react-native-screens
         kotlinVersion = "1.6.10"
         ndkVersion = "21.4.7075529"


### PR DESCRIPTION
Closes #1058

Notes:

- This is NOT an upgrade of React Native to a version that includes changes that fulfill the SDK requirements. This is an attempt to do the bare minimum to fulfill the requirement.
- The project now uses JDK 11 and not JDK 8. Instructions for how to install JDK 11 can be found in the **0.67** version of the React Native docs: https://reactnative.dev/docs/0.67/environment-setup
  - If you have multiple installations of JDK (check by running some variation of `/usr/libexec/java_home -V`), make sure you use 11 when working with this project.
  - I added a small change to the contributing docs to point to the React Native instructions for setting up the development environment
- Upgrading the target sdk caused an [issue with the Mapbox telemetry android module](https://github.com/rnmapbox/maps/issues/1677) when targeting 31 but using 8.5.0 of the mapbox-gl react native dep, sending me through a loop in order to find a fix for it. Basically, we have to manually specify the Android dep versions we want in order to properly fix that issue, which is a little hazardous. Most notably, we upgrade the Android SDK from 9.1.0 to 9.7.2, but based on the [changelog](https://github.com/mapbox/mapbox-gl-native-android/blob/main/CHANGELOG.md), it doesn't seem like there's anything too worrying (could be entirely wrong).
- i wrote a decently extensive comment about it, but we couldn't upgrade the `buildToolsVersion` to 31 for the following reasons:
  - non-blocking
    - requires upgrading to Gradle 7, gradle wrapper 7, and android gradle plugin 7
    - requires upgrading Bugsnag gradle plugin to 7 
  - blocking
    - upgrading to Gradle 7 requires upgrading every Expo module we rely on (see https://github.com/expo/expo/issues/12774). not a task I was ready to take on given the anticipated pre-requisite of moving away from unimodules
- overall, targeting 31 seems to require very minimal code changes. only things I had to update were a couple of android xml files.
- I was able to test this on my main phone (which runs Android 13) and my development phone (Android 11). both of them seemed to work fine for basic functionality.
- requires using [v2 of our docker image](https://github.com/digidem/docker-android/)