### PR TITLE
fix: localized messages not being extracted

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -150,6 +150,12 @@
   "screens.AppPasscode.ConfirmPasscodeSheet.title": {
     "message": "App Passcodes can never be recovered if lost or forgotten! Make sure to note your passcode in a secure location before saving."
   },
+  "screens.AppPasscode.EnterPassToTurnOff.subTitleEnter": {
+    "message": "Please Enter Passcode"
+  },
+  "screens.AppPasscode.EnterPassToTurnOff.titleEnter": {
+    "message": "Enter Passcode"
+  },
   "screens.AppPasscode.InputPasscodeScreen.cancel": {
     "message": "Cancel"
   },
@@ -170,6 +176,9 @@
   },
   "screens.AppPasscode.NewPasscode.InputPasscodeScreen.passwordDoesNotMatch": {
     "message": "Password does not match"
+  },
+  "screens.AppPasscode.NewPasscode.InputPasscodeScreen.passwordError": {
+    "message": "Incorrect Passcode"
   },
   "screens.AppPasscode.NewPasscode.InputPasscodeScreen.subTitleSet": {
     "message": "This passcode will be required to open the Mapeo App"
@@ -347,6 +356,30 @@
   },
   "screens.LeaveProject.LeaveProject": {
     "message": "Leave Project"
+  },
+  "screens.LeaveProject.LeaveProject.agreeToDelete": {
+    "message": "I understand I will be deleting all data from my device."
+  },
+  "screens.LeaveProject.LeaveProject.cancel": {
+    "message": "Cancel"
+  },
+  "screens.LeaveProject.LeaveProject.confirmDelete": {
+    "message": "Please check the box to confirm"
+  },
+  "screens.LeaveProject.LeaveProject.headerTitle": {
+    "message": "Leave Project"
+  },
+  "screens.LeaveProject.LeaveProject.leaveButton": {
+    "message": "Leave Project"
+  },
+  "screens.LeaveProject.LeaveProject.leaveProjectTitle": {
+    "message": "Leave Project{projectName}?"
+  },
+  "screens.LeaveProject.LeaveProject.syncWarning": {
+    "message": "Sync with a team member so you don't loose all your observations."
+  },
+  "screens.LeaveProject.LeaveProject.willDelete": {
+    "message": "This will delete {numOfObservations} observations and {numOfPics} Pictures"
   },
   "screens.LeaveProject.LeaveProjectCompleted.goHome": {
     "message": "Go Home"

--- a/src/frontend/screens/AppPasscode/EnterPassToTurnOff.tsx
+++ b/src/frontend/screens/AppPasscode/EnterPassToTurnOff.tsx
@@ -1,16 +1,16 @@
 import * as React from "react";
-import { defineMessage } from "react-intl";
+import { defineMessages } from "react-intl";
 import { PasscodeScreens } from ".";
 import { SecurityContext } from "../../context/SecurityContext";
 import { InputPasscode } from "./InputPasscode";
 
-const m = defineMessage({
+const m = defineMessages({
   titleEnter: {
-    id: "screens.AppPasscode.NewPasscode.InputPasscodeScreen.titleEnter",
+    id: "screens.AppPasscode.EnterPassToTurnOff.titleEnter",
     defaultMessage: "Enter Passcode",
   },
   subTitleEnter: {
-    id: "screens.AppPasscode.NewPasscode.InputPasscodeScreen.subTitleEnter",
+    id: "screens.AppPasscode.EnterPassToTurnOff.subTitleEnter",
     defaultMessage: "Please Enter Passcode",
   },
   passwordError: {

--- a/src/frontend/screens/LeaveProject/LeaveProjectInitial.tsx
+++ b/src/frontend/screens/LeaveProject/LeaveProjectInitial.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useState } from "react";
-import { defineMessage, FormattedMessage } from "react-intl";
+import { defineMessages, FormattedMessage } from "react-intl";
 import { View, Text, StyleSheet, Image } from "react-native";
 import CheckBox from "@react-native-community/checkbox";
 import ConfigContext from "../../context/ConfigContext";
@@ -7,7 +7,7 @@ import Button from "../../sharedComponents/Button";
 import { LeaveProjSharedProp } from ".";
 import { useNavigationFromRoot } from "../../hooks/useNavigationWithTypes";
 
-const m = defineMessage({
+const m = defineMessages({
   leaveProjectTitle: {
     id: "screens.LeaveProject.LeaveProject.leaveProjectTitle",
     defaultMessage: "Leave Project{projectName}?",


### PR DESCRIPTION
Fix for `defineMessage` being used, instead of `defineMessaged`

This is being pushed to develop, in order for the new extracted string to be available in crowdin.

After this is merged, branch Release/v5.5.0 will be rebased off develop, to be included in the upcoming release.