### PR TITLE
chore: created android native module for flag secure

### DIFF
--- a/android/app/src/main/java/com/mapeo/AppInfoPackage.java
+++ b/android/app/src/main/java/com/mapeo/AppInfoPackage.java
@@ -21,6 +21,7 @@ public class AppInfoPackage implements ReactPackage {
     List<NativeModule> modules = new ArrayList<>();
 
     modules.add(new AppInfoModule(reactContext));
+    modules.add(new FlagSecureModule(reactContext));
 
     return modules;
   }

--- a/android/app/src/main/java/com/mapeo/FlagSecureModule.java
+++ b/android/app/src/main/java/com/mapeo/FlagSecureModule.java
@@ -1,3 +1,4 @@
+// Based off https://github.com/kristiansorens/react-native-flag-secure-android 
 package com.mapeo;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
@@ -7,28 +8,22 @@ import com.facebook.react.bridge.ReactMethod;
 import android.app.Activity;
 import android.view.WindowManager;
 
-public class FlagSecureModule extends ReactContextBaseJavaModule 
-{
-    FlagSecureModule(ReactApplicationContext context) 
-    {
+public class FlagSecureModule extends ReactContextBaseJavaModule {
+    FlagSecureModule(ReactApplicationContext context) {
         super(context);
     }
 
     @Override
-    public String getName() 
-    {
+    public String getName() {
         return "FlagSecureModule";
     }
 
     @ReactMethod
-    public void activate() 
-    {
+    public void activate() {
         final Activity activity = getCurrentActivity();
 
-        if (activity != null) 
-        {
-            activity.runOnUiThread(new Runnable() 
-            {
+        if (activity != null) {
+            activity.runOnUiThread(new Runnable() {
                 @Override
                 public void run() 
                 {
@@ -44,8 +39,7 @@ public class FlagSecureModule extends ReactContextBaseJavaModule
     }
     
     @ReactMethod
-    public void deactivate() 
-    {
+    public void deactivate() {
         final Activity activity = getCurrentActivity();
         
         if (activity != null) {

--- a/android/app/src/main/java/com/mapeo/FlagSecureModule.java
+++ b/android/app/src/main/java/com/mapeo/FlagSecureModule.java
@@ -1,0 +1,60 @@
+package com.mapeo;
+import com.facebook.react.bridge.NativeModule;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import android.app.Activity;
+import android.view.WindowManager;
+
+public class FlagSecureModule extends ReactContextBaseJavaModule 
+{
+    FlagSecureModule(ReactApplicationContext context) 
+    {
+        super(context);
+    }
+
+    @Override
+    public String getName() 
+    {
+        return "FlagSecureModule";
+    }
+
+    @ReactMethod
+    public void activate() 
+    {
+        final Activity activity = getCurrentActivity();
+
+        if (activity != null) 
+        {
+            activity.runOnUiThread(new Runnable() 
+            {
+                @Override
+                public void run() 
+                {
+                    activity.getWindow().setFlags(
+                        WindowManager.LayoutParams.FLAG_SECURE,
+                        WindowManager.LayoutParams.FLAG_SECURE
+                    );
+                }
+            });
+        }
+
+        
+    }
+    
+    @ReactMethod
+    public void deactivate() 
+    {
+        final Activity activity = getCurrentActivity();
+        
+        if (activity != null) {
+            activity.runOnUiThread(new Runnable() {
+                @Override
+                public void run() {
+                    activity.getWindow().clearFlags(WindowManager.LayoutParams.FLAG_SECURE);
+                }
+            });
+        }
+    }
+}

--- a/src/frontend/context/SecurityContext.tsx
+++ b/src/frontend/context/SecurityContext.tsx
@@ -1,8 +1,10 @@
 import * as React from "react";
-import { AppState, AppStateStatus } from "react-native";
+import { AppState, AppStateStatus, NativeModules } from "react-native";
 
 import { OBSCURE_KEY, OBSCURE_PASSCODE, PASSWORD_KEY } from "../constants";
 import createPersistedState from "../hooks/usePersistedState";
+
+const { FlagSecureModule } = NativeModules;
 
 type AuthState = "unauthenticated" | "authenticated" | "obscured";
 
@@ -113,8 +115,12 @@ const SecurityProviderInner = ({
       if (passcodeValue === null) {
         setAuthState("authenticated");
         setObscureCode(null);
+        setPasscode(passcodeValue);
+        FlagSecureModule.deactivate();
+        return;
       }
 
+      FlagSecureModule.activate();
       setPasscode(passcodeValue);
     },
     [obscureCode]


### PR DESCRIPTION
# Flag Secure to obscure screen when in background
Flag Secure is a native android api that makes it so the user is unable to see the screen while the screen is in the background. This is turned on when passcode is turned on by the user and turned off when passcode is turned off by the user.

Addresses [QA Bug](https://www.notion.so/digidem/Tech-Priorities-a8bb127b4ba94322ae2a8cd75477e949?p=f56c34199e8843db90d8d2c0ba414b95&pm=s)

![Kapture 2023-02-11 at 21 13 50](https://user-images.githubusercontent.com/67773827/218281454-6304ab75-7ee4-4be8-9701-fa325d653585.gif)

