### PR TITLE
chore: changed link to "here"

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -819,6 +819,10 @@
   "screens.Settings.Experiments.BGMaps.goTo": {
     "message": "Try it now"
   },
+  "screens.Settings.Experiments.BGMaps.shortLink": {
+    "description": "Used as a link to the gitbooks documentation for adding background maps",
+    "message": "here."
+  },
   "screens.Settings.Experiments.BGMaps.useBGMap": {
     "message": "Use Background Maps (Feature)"
   },

--- a/src/frontend/screens/Settings/Experiments/BackgroundMaps.tsx
+++ b/src/frontend/screens/Settings/Experiments/BackgroundMaps.tsx
@@ -41,6 +41,12 @@ const m = defineMessages({
     defaultMessage:
       "WARNING: When this feature is enabled, you will not have access to the map you had previously been using in Mapeo. Turn off Map Manager to switch back to your previous map. Please note that this feature is still in the pilot testing phase and you will need to re-import any maps added to the Map Manager once the final version is released.",
   },
+  shortLink: {
+    id: "screens.Settings.Experiments.BGMaps.shortLink",
+    description:
+      "Used as a link to the gitbooks documentation for adding background maps",
+    defaultMessage: "here.",
+  },
 });
 
 export const BackgroundMapsSettings: NativeNavigationComponent<"BGMapsSettings"> = ({
@@ -66,11 +72,11 @@ export const BackgroundMapsSettings: NativeNavigationComponent<"BGMapsSettings">
           ]}
           onPress={() => {
             Linking.openURL(
-              "https://docs.mapeo.app/complete-reference-guide/mapeo-mobile-installation-setup/adding-custom-base-maps-to-mapeo-mobile/add-maps-to-map-manager"
+              "https://docs.mapeo.app/complete-reference-guide/customization-options/custom-base-maps/creating-custom-maps/creating-mbtiles"
             );
           }}
         >
-          https://docs.mapeo.app/complete-reference-guide/mapeo-mobile-installation-setup/adding-custom-base-maps-to-mapeo-mobile/add-maps-to-map-manager
+          {t(m.shortLink)}
         </Text>
       </View>
       <Text style={styles.text}>{t(m.feedBack)}</Text>


### PR DESCRIPTION
# Updated link for gitbooks to be less verbose
In Experimental Features>Background Maps, the link to the online gitbooks page has been updated to the correct link. The url has also been hidden and now the user can click on "here"

<img width="288" alt="image" src="https://user-images.githubusercontent.com/67773827/218313046-39425db1-3ac5-46fd-837d-7269001ec020.png">


