### PR TITLE
chore: convert passcode screen to native nav

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -191,6 +191,9 @@
   "screens.AppPasscode.NewPasscode.InputPasscodeScreen.subTitleSet": {
     "message": "This passcode will be required to open the Mapeo App"
   },
+  "screens.AppPasscode.NewPasscode.InputPasscodeScreen.title": {
+    "message": "Set Passcode"
+  },
   "screens.AppPasscode.NewPasscode.Splash.continue": {
     "message": "Continue"
   },
@@ -214,6 +217,9 @@
   },
   "screens.AppPasscode.TurnOffPasscode.description": {
     "message": "App Passcode adds an additional layer of security by requiring that you enter a passcode in order to open the Mapeo app."
+  },
+  "screens.AppPasscode.TurnOffPasscode.title": {
+    "message": "App Passcode"
   },
   "screens.AppPasscode.TurnOffPasscode.turnOff": {
     "message": "Turn Off"

--- a/src/frontend/Navigation/ScreenGroups/AppScreens.tsx
+++ b/src/frontend/Navigation/ScreenGroups/AppScreens.tsx
@@ -44,8 +44,11 @@ import { AuthScreen } from "../../screens/AuthScreen";
 import { RootStack } from "../AppStack";
 import { BackgroundMapInfo } from "../../screens/Settings/MapSettings/BackgroundMapInfo";
 import { AppPasscode } from "../../screens/AppPasscode";
+import { TurnOffPasscode } from "../../screens/AppPasscode/TurnOffPasscode";
 import { ConfirmPasscodeSheet } from "../../screens/AppPasscode/ConfirmPasscodeSheet";
 import { ObscurePasscode } from "../../screens/ObscurePasscode";
+import { SetPasscode } from "../../screens/AppPasscode/SetPasscode";
+import { EnterPassToTurnOff } from "../../screens/AppPasscode/EnterPassToTurnOff";
 
 export type HomeTabsList = {
   Map: undefined;
@@ -97,6 +100,9 @@ export type AppList = {
   AppPasscode: undefined;
   ObscurePasscode: undefined;
   ConfirmPasscodeSheet: { passcode: string };
+  DisablePasscode: undefined;
+  SetPasscode: undefined;
+  EnterPassToTurnOff: undefined;
 };
 
 const Tab = createBottomTabNavigator<HomeTabsList>();
@@ -280,6 +286,21 @@ export const createDefaultScreenGroup = (
       name="AppPasscode"
       component={AppPasscode}
       options={{ headerTitle: intl(AppPasscode.navTitle) }}
+    />
+    <RootStack.Screen
+      name="DisablePasscode"
+      component={TurnOffPasscode}
+      options={{ headerTitle: intl(TurnOffPasscode.navTitle) }}
+    />
+    <RootStack.Screen
+      name="SetPasscode"
+      component={SetPasscode}
+      options={{ headerTitle: intl(SetPasscode.navTitle) }}
+    />
+    <RootStack.Screen
+      name="EnterPassToTurnOff"
+      component={EnterPassToTurnOff}
+      options={{ headerTitle: intl(EnterPassToTurnOff.navTitle) }}
     />
     <RootStack.Screen
       name="ObscurePasscode"

--- a/src/frontend/screens/AppPasscode/EnterPassToTurnOff.tsx
+++ b/src/frontend/screens/AppPasscode/EnterPassToTurnOff.tsx
@@ -1,7 +1,8 @@
 import * as React from "react";
 import { defineMessages } from "react-intl";
-import { PasscodeScreens } from ".";
+
 import { SecurityContext } from "../../context/SecurityContext";
+import { NativeNavigationComponent } from "../../sharedTypes";
 import { InputPasscode } from "./InputPasscode";
 
 const m = defineMessages({
@@ -17,31 +18,32 @@ const m = defineMessages({
     id: "screens.AppPasscode.NewPasscode.InputPasscodeScreen.passwordError",
     defaultMessage: "Incorrect Passcode",
   },
+  title: {
+    id: "screens.AppPasscode.NewPasscode.InputPasscodeScreen.title",
+    defaultMessage: "Confirm Passcode",
+  },
 });
 
-export const EnterPassToTurnOff = ({
-  setScreenState,
-}: {
-  setScreenState: React.Dispatch<React.SetStateAction<PasscodeScreens>>;
+export const EnterPassToTurnOff: NativeNavigationComponent<"EnterPassToTurnOff"> = ({
+  navigation,
 }) => {
-  const { authenticate } = React.useContext(SecurityContext);
+  const { authenticate, authValuesSet } = React.useContext(SecurityContext);
   const [error, setError] = React.useState(false);
-  const [pass, setPass] = React.useState("");
+  const { navigate } = navigation;
 
-  function validate() {
-    if (!authenticate(pass, true)) {
+  // Stops user from accessing this page if no password is set
+  React.useLayoutEffect(() => {
+    if (!authValuesSet.passcodeSet) {
+      navigate("Security");
+    }
+  }, [navigate, authValuesSet]);
+
+  function validate(passcode: string) {
+    if (!authenticate(passcode, true)) {
       setError(true);
       return;
     }
-    setScreenState("disablePasscode");
-  }
-
-  function setPassWithValidation(passValue: string) {
-    if (error && passValue.length > 0) {
-      setError(false);
-    }
-
-    setPass(passValue);
+    navigate("DisablePasscode");
   }
 
   return (
@@ -53,8 +55,10 @@ export const EnterPassToTurnOff = ({
       }}
       error={error}
       validate={validate}
-      inputValue={pass}
-      setInputValue={setPassWithValidation}
+      showNext={false}
+      hideError={() => setError(false)}
     />
   );
 };
+
+EnterPassToTurnOff.navTitle = m.title;

--- a/src/frontend/screens/AppPasscode/InputPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/InputPasscode.tsx
@@ -6,6 +6,7 @@ import {
 } from "react-intl";
 import { View, StyleSheet, Text, ScrollView } from "react-native";
 import { useBlurOnFulfill } from "react-native-confirmation-code-field";
+
 import { useNavigationFromRoot } from "../../hooks/useNavigationWithTypes";
 import { WHITE, RED, MAPEO_BLUE } from "../../lib/styles";
 import Button from "../../sharedComponents/Button";
@@ -30,11 +31,11 @@ interface InputPasscodeProps {
     subtitle: MessageDescriptor;
     errorMessage: MessageDescriptor;
   };
-  validate: () => void;
+  validate: (pass: string) => void;
   showPasscodeValues?: boolean;
   error: boolean;
-  inputValue: string;
-  setInputValue: (val: string) => void;
+  hideError: () => void;
+  showNext?: boolean;
 }
 
 export const InputPasscode = ({
@@ -42,9 +43,11 @@ export const InputPasscode = ({
   text,
   showPasscodeValues,
   error,
-  inputValue,
-  setInputValue,
+  hideError,
+  showNext = true,
 }: InputPasscodeProps) => {
+  const [inputValue, setInputValue] = React.useState("");
+
   const inputRef = useBlurOnFulfill({
     value: inputValue,
     cellCount: CELL_COUNT,
@@ -52,7 +55,13 @@ export const InputPasscode = ({
 
   if (error) inputRef.current?.focus();
 
-  const { goBack } = useNavigationFromRoot();
+  function updateInput(newVal: string) {
+    if (error) hideError();
+    setInputValue(newVal);
+    if (!showNext && newVal.length === 5) validate(newVal);
+  }
+
+  const { navigate } = useNavigationFromRoot();
   return (
     <ScrollView>
       <View style={styles.container}>
@@ -68,7 +77,7 @@ export const InputPasscode = ({
             error={error}
             ref={inputRef}
             inputValue={inputValue}
-            onChangeTextWithValidation={setInputValue}
+            onChangeTextWithValidation={updateInput}
             maskValues={!showPasscodeValues}
           />
 
@@ -84,18 +93,28 @@ export const InputPasscode = ({
             fullWidth
             variant="outlined"
             style={{ marginBottom: 20, marginTop: 20 }}
-            onPress={goBack}
+            onPress={() => {
+              navigate("Security");
+            }}
           >
             <Text style={[styles.buttonText, { color: MAPEO_BLUE }]}>
               <FormattedMessage {...m.cancel} />
             </Text>
           </Button>
 
-          <Button fullWidth onPress={validate}>
-            <Text style={[styles.buttonText, { color: WHITE }]}>
-              <FormattedMessage {...m.button} />
-            </Text>
-          </Button>
+          {showNext && (
+            <Button
+              fullWidth
+              onPress={() => {
+                console.log(inputValue);
+                validate(inputValue);
+              }}
+            >
+              <Text style={[styles.buttonText, { color: WHITE }]}>
+                <FormattedMessage {...m.button} />
+              </Text>
+            </Button>
+          )}
         </View>
       </View>
     </ScrollView>

--- a/src/frontend/screens/AppPasscode/InputPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/InputPasscode.tsx
@@ -106,7 +106,6 @@ export const InputPasscode = ({
             <Button
               fullWidth
               onPress={() => {
-                console.log(inputValue);
                 validate(inputValue);
               }}
             >

--- a/src/frontend/screens/AppPasscode/PasscodeIntro.tsx
+++ b/src/frontend/screens/AppPasscode/PasscodeIntro.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { defineMessages, useIntl } from "react-intl";
 import { StyleSheet, Text, View, ScrollView } from "react-native";
 
-import { PasscodeScreens } from ".";
+import { useNavigationFromRoot } from "../../hooks/useNavigationWithTypes";
 import Button from "../../sharedComponents/Button";
 
 const m = defineMessages({
@@ -26,12 +26,9 @@ const m = defineMessages({
   },
 });
 
-interface PasscodeIntroProps {
-  setScreen: React.Dispatch<React.SetStateAction<PasscodeScreens>>;
-}
-
-export const PasscodeIntro = ({ setScreen }: PasscodeIntroProps) => {
+export const PasscodeIntro = () => {
   const { formatMessage: t } = useIntl();
+  const { navigate } = useNavigationFromRoot();
 
   return (
     <ScrollView>
@@ -46,7 +43,7 @@ export const PasscodeIntro = ({ setScreen }: PasscodeIntroProps) => {
         <View>
           <Button
             style={[styles.button]}
-            onPress={() => setScreen("setPasscode")}
+            onPress={() => navigate("SetPasscode")}
           >
             {t(m.continue)}
           </Button>

--- a/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
@@ -184,6 +184,7 @@ const ConfirmTurnOffPasswordModal = React.forwardRef<
       enableContentPanningGesture={false}
       enableHandlePanningGesture={false}
       handleHeight={0}
+      handleComponent={() => null}
       index={-1}
     >
       <View

--- a/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
@@ -174,9 +174,6 @@ const ConfirmTurnOffPasswordModal = React.forwardRef<
     "40%",
   ]);
 
-  // This is crude, but it is suddenly opening and then closing if I don't do this...
-  React.useLayoutEffect(() => closeSheet(), [closeSheet]);
-
   const { formatMessage: t } = useIntl();
 
   return (
@@ -187,6 +184,7 @@ const ConfirmTurnOffPasswordModal = React.forwardRef<
       enableContentPanningGesture={false}
       enableHandlePanningGesture={false}
       handleHeight={0}
+      index={-1}
     >
       <View
         onLayout={e => {

--- a/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
+++ b/src/frontend/screens/AppPasscode/TurnOffPasscode.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { StyleSheet, Text, View } from "react-native";
+import { BackHandler, StyleSheet, Text, View } from "react-native";
 import { defineMessages, FormattedMessage, useIntl } from "react-intl";
 import MaterialIcon from "react-native-vector-icons/MaterialIcons";
 import BottomSheet, { BottomSheetBackdrop } from "@gorhom/bottom-sheet";
@@ -13,11 +13,13 @@ import {
   ListItem,
   ListItemText,
 } from "../../sharedComponents/List";
-import { MEDIUM_GREY, RED } from "../../lib/styles";
-import { PasscodeScreens } from ".";
-import { useNavigationFromRoot } from "../../hooks/useNavigationWithTypes";
+import { MEDIUM_GREY, RED, WHITE } from "../../lib/styles";
 import { ErrorIcon } from "../../sharedComponents/icons";
 import Button from "../../sharedComponents/Button";
+import { NativeNavigationComponent } from "../../sharedTypes";
+import { useFocusEffect, StackActions } from "@react-navigation/native";
+import CustomHeaderLeft from "../../sharedComponents/CustomHeaderLeft";
+import { HeaderButtonProps } from "@react-navigation/native-stack/lib/typescript/src/types";
 
 const m = defineMessages({
   usePasscode: {
@@ -50,20 +52,52 @@ const m = defineMessages({
     defaultMessage:
       "You are currently using App Passcode. See below to stop using or change your passcode.",
   },
+  title: {
+    id: "screens.AppPasscode.TurnOffPasscode.title",
+    defaultMessage: "App Passcode",
+  },
 });
 
-interface TurnOffPasscodeProps {
-  setScreenState: (screen: PasscodeScreens) => void;
-}
-
-export const TurnOffPasscode = ({ setScreenState }: TurnOffPasscodeProps) => {
+export const TurnOffPasscode: NativeNavigationComponent<"DisablePasscode"> = ({
+  navigation,
+}) => {
   const { authValuesSet, setAuthValues } = React.useContext(SecurityContext);
 
   const sheetRef = React.useRef<BottomSheetMethods>(null);
 
-  const { navigate } = useNavigationFromRoot();
+  const { navigate } = navigation;
 
   const { formatMessage: t } = useIntl();
+
+  // These next three function forces the user to go back to the setting page instead of the "EnterPassToTurnOff" screen
+  const backPress = React.useCallback(() => {
+    const popAction = StackActions.pop(2);
+    navigation.dispatch(popAction);
+  }, [navigation]);
+
+  React.useLayoutEffect(() => {
+    navigation.setOptions({
+      headerLeft: (props: HeaderButtonProps) => (
+        <CustomHeaderLeft headerBackButtonProps={props} onPress={backPress} />
+      ),
+    });
+  }, [backPress, navigation]);
+
+  useFocusEffect(
+    React.useCallback(() => {
+      const onBackPress = () => {
+        backPress();
+        return true;
+      };
+
+      const subscription = BackHandler.addEventListener(
+        "hardwareBackPress",
+        onBackPress
+      );
+
+      return () => subscription.remove();
+    }, [backPress])
+  );
 
   function unsetAppPasscode() {
     setAuthValues({ type: "passcode", value: null });
@@ -75,7 +109,7 @@ export const TurnOffPasscode = ({ setScreenState }: TurnOffPasscodeProps) => {
   }
 
   return (
-    <React.Fragment>
+    <View style={styles.pageContainer}>
       <Text style={styles.description}>{t(m.description)}</Text>
       <Text style={{ fontSize: 16, marginBottom: 20 }}>
         {t(m.currentlyUsing)}
@@ -104,7 +138,7 @@ export const TurnOffPasscode = ({ setScreenState }: TurnOffPasscodeProps) => {
         {authValuesSet.passcodeSet && (
           <ListItem
             onPress={() => {
-              setScreenState("setPasscode");
+              navigate("SetPasscode");
             }}
             style={{ marginTop: 20 }}
           >
@@ -122,23 +156,26 @@ export const TurnOffPasscode = ({ setScreenState }: TurnOffPasscodeProps) => {
           sheetRef.current?.close();
         }}
       />
-    </React.Fragment>
+    </View>
   );
 };
 
-interface ConfirmTurnOffPasswordModal {
+interface ConfirmTurnOffPasswordModalProps {
   turnOffPasscode: () => void;
   closeSheet: () => void;
 }
 
 const ConfirmTurnOffPasswordModal = React.forwardRef<
   BottomSheetMethods,
-  ConfirmTurnOffPasswordModal
+  ConfirmTurnOffPasswordModalProps
 >(({ turnOffPasscode, closeSheet }, sheetRef) => {
   const [snapPoints, setSnapPoints] = React.useState<(number | string)[]>([
     0,
     "40%",
   ]);
+
+  // This is crude, but it is suddenly opening and then closing if I don't do this...
+  React.useLayoutEffect(() => closeSheet(), [closeSheet]);
 
   const { formatMessage: t } = useIntl();
 
@@ -150,7 +187,6 @@ const ConfirmTurnOffPasswordModal = React.forwardRef<
       enableContentPanningGesture={false}
       enableHandlePanningGesture={false}
       handleHeight={0}
-      handleComponent={() => null}
     >
       <View
         onLayout={e => {
@@ -179,6 +215,8 @@ const ConfirmTurnOffPasswordModal = React.forwardRef<
   );
 });
 
+TurnOffPasscode.navTitle = m.title;
+
 const styles = StyleSheet.create({
   text: {
     fontSize: 16,
@@ -199,5 +237,11 @@ const styles = StyleSheet.create({
     marginTop: 40,
     fontSize: 16,
     marginBottom: 20,
+  },
+  pageContainer: {
+    paddingBottom: 20,
+    paddingHorizontal: 20,
+    flex: 1,
+    backgroundColor: WHITE,
   },
 });

--- a/src/frontend/screens/AppPasscode/index.tsx
+++ b/src/frontend/screens/AppPasscode/index.tsx
@@ -1,15 +1,11 @@
 import * as React from "react";
 import { defineMessages } from "react-intl";
 import { StyleSheet, View } from "react-native";
-import { SecurityContext } from "../../context/SecurityContext";
 
+import { SecurityContext } from "../../context/SecurityContext";
 import { WHITE } from "../../lib/styles";
 import { NativeNavigationComponent } from "../../sharedTypes";
-import { EnterPassToTurnOff } from "./EnterPassToTurnOff";
-
 import { PasscodeIntro } from "./PasscodeIntro";
-import { SetPassword } from "./SetPasscode";
-import { TurnOffPasscode } from "./TurnOffPasscode";
 
 const m = defineMessages({
   title: {
@@ -18,43 +14,22 @@ const m = defineMessages({
   },
 });
 
-export type PasscodeScreens =
-  | "intro"
-  | "setPasscode"
-  | "enterPasscode"
-  | "disablePasscode";
-
 export const AppPasscode: NativeNavigationComponent<"AppPasscode"> = ({
   navigation,
 }) => {
-  const { authValuesSet, authState } = React.useContext(SecurityContext);
-  const [screenState, setScreenState] = React.useState<PasscodeScreens>(() =>
-    authValuesSet.passcodeSet ? "enterPasscode" : "intro"
-  );
+  const { authState } = React.useContext(SecurityContext);
 
-  React.useEffect(() => {
+  React.useLayoutEffect(() => {
     if (authState === "obscured") {
       navigation.navigate("Settings");
     }
   }, [navigation, authState]);
 
-  const screen = React.useMemo(() => {
-    if (screenState === "intro") {
-      return <PasscodeIntro setScreen={setScreenState} />;
-    }
-
-    if (screenState === "setPasscode") {
-      return <SetPassword setScreen={setScreenState} />;
-    }
-
-    if (screenState === "enterPasscode") {
-      return <EnterPassToTurnOff setScreenState={setScreenState} />;
-    }
-
-    return <TurnOffPasscode setScreenState={setScreenState} />;
-  }, [screenState]);
-
-  return <View style={styles.pageContainer}>{screen}</View>;
+  return (
+    <View style={styles.pageContainer}>
+      <PasscodeIntro />
+    </View>
+  );
 };
 
 AppPasscode.navTitle = m.title;

--- a/src/frontend/screens/Security/index.tsx
+++ b/src/frontend/screens/Security/index.tsx
@@ -76,7 +76,11 @@ export const Security: NativeNavigationComponent<"Security"> = ({
       <List>
         <ListItem
           button={true}
-          onPress={() => navigation.navigate("AppPasscode")}
+          onPress={() =>
+            navigation.navigate(
+              !authValuesSet.passcodeSet ? "AppPasscode" : "EnterPassToTurnOff"
+            )
+          }
         >
           <ListItemText
             primary={<FormattedMessage {...m.passcodeHeader} />}


### PR DESCRIPTION
# Converted passcode screens to utilize `React Navigation`

Passcode Screen were previously not using native navigation to go in between screen. This PR converts them to `Stack Nav Screens` using `React Navigation`

Also fixes a bottom modal flicker when user was navigated to turn off App Passcode.

Finally, takes away the next button in `EnterPassToTurnOff` Screen. Addresses [QA suggested improvement](https://www.notion.so/digidem/Tech-Priorities-a8bb127b4ba94322ae2a8cd75477e949?p=f53fa66c6a054fb4bb10c12d93ebd67f&pm=s)