### PR TITLE
fix: fix issues with BottomSheetModal implementation

### DIFF
--- a/src/frontend/App.js
+++ b/src/frontend/App.js
@@ -6,7 +6,7 @@ import { LogBox } from "react-native";
 import SplashScreen from "react-native-splash-screen";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 
-// We need to wrap the app with this provider to fix an the bottom sheet modal backdrop
+// We need to wrap the app with this provider to fix an issue with the bottom sheet modal backdrop
 // not overlaying the navigation header. Without this, the header is accessible even when
 // the modal is open, which we don't want (e.g. header back button shouldn't be reachable).
 // See https://github.com/gorhom/react-native-bottom-sheet/issues/1157

--- a/src/frontend/App.js
+++ b/src/frontend/App.js
@@ -5,6 +5,11 @@ import * as React from "react";
 import { LogBox } from "react-native";
 import SplashScreen from "react-native-splash-screen";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+
+// We need to wrap the app with this provider to fix an the bottom sheet modal backdrop
+// not overlaying the navigation header. Without this, the header is accessible even when
+// the modal is open, which we don't want (e.g. header back button shouldn't be reachable).
+// See https://github.com/gorhom/react-native-bottom-sheet/issues/1157
 import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
 import ErrorScreen from "./screens/UncaughtError";

--- a/src/frontend/App.js
+++ b/src/frontend/App.js
@@ -5,6 +5,7 @@ import * as React from "react";
 import { LogBox } from "react-native";
 import SplashScreen from "react-native-splash-screen";
 import AsyncStorage from "@react-native-async-storage/async-storage";
+import { BottomSheetModalProvider } from "@gorhom/bottom-sheet";
 
 import ErrorScreen from "./screens/UncaughtError";
 import { AppLoading } from "./AppLoading";
@@ -51,7 +52,9 @@ const App = () => (
       <PermissionsProvider>
         <AppLoading>
           <AppProvider>
-            <AppContainerWrapper />
+            <BottomSheetModalProvider>
+              <AppContainerWrapper />
+            </BottomSheetModalProvider>
             <UpdateNotifier />
           </AppProvider>
         </AppLoading>

--- a/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
+++ b/src/frontend/screens/AppPasscode/ConfirmPasscodeSheet.tsx
@@ -38,7 +38,9 @@ export const ConfirmPasscodeSheet = ({
 }: NativeRootNavigationProps<"ConfirmPasscodeSheet">) => {
   const { formatMessage: t } = useIntl();
   const { setAuthValues } = React.useContext(SecurityContext);
-  const { sheetRef } = useBottomSheetModal({ openOnMount: true });
+  const { sheetRef, isOpen } = useBottomSheetModal({
+    openOnMount: true,
+  });
   const { passcode } = route.params;
 
   function setPasscodeAndNavigateBack() {
@@ -47,7 +49,7 @@ export const ConfirmPasscodeSheet = ({
   }
 
   return (
-    <BottomSheetModal ref={sheetRef} onDismiss={() => {}}>
+    <BottomSheetModal ref={sheetRef} isOpen={isOpen}>
       <BottomSheetContent
         titleStyle={styles.text}
         descriptionStyle={styles.text}

--- a/src/frontend/screens/JoinRequestModal.tsx
+++ b/src/frontend/screens/JoinRequestModal.tsx
@@ -56,7 +56,9 @@ export const JoinRequestModal = ({
 
   const [config] = React.useContext(ConfigContext);
 
-  const { sheetRef, closeSheet } = useBottomSheetModal({ openOnMount: true });
+  const { sheetRef, isOpen, closeSheet } = useBottomSheetModal({
+    openOnMount: true,
+  });
 
   const projectName = config.metadata.name;
   const deviceName = route.params?.deviceName || "";
@@ -77,7 +79,11 @@ export const JoinRequestModal = ({
   };
 
   return (
-    <BottomSheetModal ref={sheetRef} onDismiss={navigation.goBack}>
+    <BottomSheetModal
+      ref={sheetRef}
+      isOpen={isOpen}
+      onDismiss={navigation.goBack}
+    >
       {step === "prompt" ? (
         <BottomSheetContent
           buttonConfigs={[

--- a/src/frontend/screens/PhotosModal/ConfirmDeleteModal.tsx
+++ b/src/frontend/screens/PhotosModal/ConfirmDeleteModal.tsx
@@ -13,6 +13,7 @@ import { ErrorIcon } from "../../sharedComponents/icons";
 
 interface ModalProps {
   sheetRef: React.RefObject<BottomSheetModalMethods>;
+  isOpen: boolean;
   photoIndex: number;
   closeSheet: () => void;
   disableBackdrop: boolean;
@@ -35,6 +36,7 @@ const m = defineMessages({
 
 export const ConfirmDeleteModal = ({
   sheetRef,
+  isOpen,
   photoIndex,
   closeSheet,
   disableBackdrop,
@@ -56,6 +58,7 @@ export const ConfirmDeleteModal = ({
   return (
     <BottomSheetModal
       ref={sheetRef}
+      isOpen={isOpen}
       disableBackrop={disableBackdrop}
       onDismiss={closeSheet}
       onHardwareBackPress={closeSheet}

--- a/src/frontend/screens/PhotosModal/ConfirmDeleteModal.tsx
+++ b/src/frontend/screens/PhotosModal/ConfirmDeleteModal.tsx
@@ -61,7 +61,7 @@ export const ConfirmDeleteModal = ({
       isOpen={isOpen}
       disableBackrop={disableBackdrop}
       onDismiss={closeSheet}
-      onHardwareBackPress={closeSheet}
+      onBack={closeSheet}
     >
       <BottomSheetContent
         buttonConfigs={[

--- a/src/frontend/screens/PhotosModal/index.tsx
+++ b/src/frontend/screens/PhotosModal/index.tsx
@@ -138,6 +138,7 @@ const PhotosModal = ({
         renderTabBar={() => null}
       />
       <ConfirmDeleteModal
+        isOpen={isOpen}
         disableBackdrop={true}
         closeSheet={closeModal}
         sheetRef={sheetRef}

--- a/src/frontend/screens/ProjectInviteModal.tsx
+++ b/src/frontend/screens/ProjectInviteModal.tsx
@@ -106,7 +106,9 @@ export const ProjectInviteModal = ({
 }: NativeRootNavigationProps<"ProjectInviteModal">) => {
   const { formatMessage: t } = useIntl();
   const isMounted = useIsMounted();
-  const { sheetRef, closeSheet } = useBottomSheetModal({ openOnMount: true });
+  const { sheetRef, isOpen, closeSheet } = useBottomSheetModal({
+    openOnMount: true,
+  });
   const [{ observations }] = React.useContext(ObservationsContext);
   const [config] = React.useContext(ConfigContext);
 
@@ -162,7 +164,11 @@ export const ProjectInviteModal = ({
   }, [fetchInviteDetails, inviteKey]);
 
   return (
-    <BottomSheetModal ref={sheetRef} onDismiss={navigation.goBack}>
+    <BottomSheetModal
+      ref={sheetRef}
+      isOpen={isOpen}
+      onDismiss={navigation.goBack}
+    >
       {status.type === "loading" ? (
         <Loading />
       ) : status.type === "error" ? (

--- a/src/frontend/screens/Settings/MapSettings/BackgroundMapInfo.tsx
+++ b/src/frontend/screens/Settings/MapSettings/BackgroundMapInfo.tsx
@@ -204,8 +204,7 @@ export const BackgroundMapInfo = ({
         mapName={name}
         mapId={id}
         closeSheet={closeSheet}
-        // If open, hardware backpress returns true, which disables the back button and vice versa
-        onHardwareBackPress={() => isOpen}
+        isOpen={isOpen}
       />
     </View>
   );

--- a/src/frontend/screens/Settings/MapSettings/DeleteMapBottomSheet.tsx
+++ b/src/frontend/screens/Settings/MapSettings/DeleteMapBottomSheet.tsx
@@ -36,13 +36,13 @@ interface DeleteMapBottomSheetProps {
   mapName: string;
   mapId: string;
   closeSheet: () => void;
-  onHardwareBackPress: () => boolean;
+  isOpen: boolean;
 }
 
 export const DeleteMapBottomSheet = React.forwardRef<
   BottomSheetModalMethods,
   DeleteMapBottomSheetProps
->(({ mapName, closeSheet, mapId, onHardwareBackPress }, sheetRef) => {
+>(({ isOpen, mapName, closeSheet, mapId }, sheetRef) => {
   const { navigate } = useNavigationFromRoot();
   const { formatMessage: t } = useIntl();
   const { selectedStyleId, setSelectedStyleId } = useMapStyles();
@@ -68,11 +68,7 @@ export const DeleteMapBottomSheet = React.forwardRef<
   }
 
   return (
-    <BottomSheetModal
-      ref={sheetRef}
-      onDismiss={closeSheet}
-      onHardwareBackPress={onHardwareBackPress}
-    >
+    <BottomSheetModal ref={sheetRef} onDismiss={closeSheet} isOpen={isOpen}>
       <BottomSheetContent
         descriptionStyle={{ fontSize: 16 }}
         title={

--- a/src/frontend/sharedComponents/BottomSheetModal/index.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/index.tsx
@@ -54,17 +54,15 @@ export const useBottomSheetModal = ({
 
 // Handles cases where Android hardware backpress button is used to trigger navigation events
 // not covered by usePreventNavigationBack
-const usePreventHardwareBackPressHandler = (
-  enable: boolean,
-  onHardwareBackPress?: () => void
-) => {
+const useBackHandler = (enable: boolean, onBack?: () => void) => {
   React.useEffect(() => {
     let subscription: NativeEventSubscription;
 
     if (enable) {
+      // This event is triggered by both Android hardware back press and gesture back swipe
       subscription = BackHandler.addEventListener("hardwareBackPress", () => {
-        if (onHardwareBackPress) {
-          onHardwareBackPress();
+        if (onBack) {
+          onBack();
         }
 
         return true;
@@ -74,7 +72,7 @@ const usePreventHardwareBackPressHandler = (
     return () => {
       if (subscription) subscription.remove();
     };
-  }, [enable, onHardwareBackPress]);
+  }, [enable, onBack]);
 };
 
 const useSnapPointsCalculator = () => {
@@ -107,17 +105,15 @@ const useSnapPointsCalculator = () => {
 interface Props extends React.PropsWithChildren<{}> {
   isOpen: boolean;
   onDismiss?: () => void;
-  onHardwareBackPress?: () => void;
+  // Triggered by: Android hardware back press and gesture back swipe
+  onBack?: () => void;
   snapPoints?: (string | number)[];
   disableBackrop?: boolean;
 }
 
 export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
-  (
-    { children, isOpen, onDismiss, onHardwareBackPress, disableBackrop },
-    ref
-  ) => {
-    usePreventHardwareBackPressHandler(isOpen, onHardwareBackPress);
+  ({ children, isOpen, onDismiss, onBack, disableBackrop }, ref) => {
+    useBackHandler(isOpen, onBack);
 
     const { snapPoints, updateSheetHeight } = useSnapPointsCalculator();
 

--- a/src/frontend/sharedComponents/BottomSheetModal/index.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/index.tsx
@@ -2,7 +2,6 @@ import * as React from "react";
 import { BackHandler, useWindowDimensions } from "react-native";
 import {
   BottomSheetModal as RNBottomSheetModal,
-  BottomSheetModalProvider,
   BottomSheetView,
 } from "@gorhom/bottom-sheet";
 import { NativeStackNavigationOptions } from "@react-navigation/native-stack";
@@ -110,29 +109,27 @@ export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
     const { snapPoints, updateSheetHeight } = useSnapPointsCalculator();
 
     return (
-      <BottomSheetModalProvider>
-        <RNBottomSheetModal
-          ref={ref}
-          backdropComponent={disableBackrop ? null : Backdrop}
-          enableContentPanningGesture={false}
-          enableHandlePanningGesture={false}
-          handleComponent={() => null}
-          index={0}
-          onDismiss={onDismiss}
-          snapPoints={snapPoints}
+      <RNBottomSheetModal
+        ref={ref}
+        backdropComponent={disableBackrop ? null : Backdrop}
+        enableContentPanningGesture={false}
+        enableHandlePanningGesture={false}
+        handleComponent={() => null}
+        index={0}
+        onDismiss={onDismiss}
+        snapPoints={snapPoints}
+      >
+        <BottomSheetView
+          onLayout={updateSheetHeight}
+          style={{
+            flex: 1,
+            paddingHorizontal: 20,
+            paddingTop: 30,
+          }}
         >
-          <BottomSheetView
-            onLayout={updateSheetHeight}
-            style={{
-              flex: 1,
-              paddingHorizontal: 20,
-              paddingTop: 30,
-            }}
-          >
-            {children}
-          </BottomSheetView>
-        </RNBottomSheetModal>
-      </BottomSheetModalProvider>
+          {children}
+        </BottomSheetView>
+      </RNBottomSheetModal>
     );
   }
 );

--- a/src/frontend/sharedComponents/BottomSheetModal/index.tsx
+++ b/src/frontend/sharedComponents/BottomSheetModal/index.tsx
@@ -10,7 +10,6 @@ import {
 } from "@gorhom/bottom-sheet";
 import { NativeStackNavigationOptions } from "@react-navigation/native-stack";
 
-import { useNavigationFromRoot } from "../../hooks/useNavigationWithTypes";
 import { Backdrop } from "./Backdrop";
 
 const MIN_SHEET_HEIGHT = 400;
@@ -52,26 +51,6 @@ export const useBottomSheetModal = ({
 
   return { sheetRef, closeSheet, openSheet, isOpen };
 };
-
-// More universal way of preventing navigation back events
-// https://reactnavigation.org/docs/preventing-going-back/
-function usePreventNavigationBack(enable: boolean) {
-  const navigation = useNavigationFromRoot();
-
-  React.useEffect(() => {
-    let unsubscribe: () => void;
-
-    if (enable) {
-      unsubscribe = navigation.addListener("beforeRemove", event => {
-        if (event.data.action.type === "GO_BACK") event.preventDefault();
-      });
-    }
-
-    return () => {
-      if (unsubscribe) unsubscribe();
-    };
-  }, [enable]);
-}
 
 // Handles cases where Android hardware backpress button is used to trigger navigation events
 // not covered by usePreventNavigationBack
@@ -138,8 +117,7 @@ export const BottomSheetModal = React.forwardRef<RNBottomSheetModal, Props>(
     { children, isOpen, onDismiss, onHardwareBackPress, disableBackrop },
     ref
   ) => {
-    usePreventNavigationBack(!!isOpen);
-    usePreventHardwareBackPressHandler(!!isOpen, onHardwareBackPress);
+    usePreventHardwareBackPressHandler(isOpen, onHardwareBackPress);
 
     const { snapPoints, updateSheetHeight } = useSnapPointsCalculator();
 


### PR DESCRIPTION
A couple of issues that are fixed:

1. The backdrop didn't overlap the native navigation header, which meant that interaction with that header was not blocked, allowing things like going back to a previous screen when the modal was opened. Now it overlaps the header and prevents interaction there, as desired.

    - Before:
    
        <img width="300" alt="image" src="https://user-images.githubusercontent.com/18542095/219113541-c3351ab8-6b5a-4218-9646-9d8e917b74e7.png">

    - After:
    
        <img width="300" alt="image" src="https://user-images.githubusercontent.com/18542095/219113424-b3358c22-dafb-49e2-9a22-4c5ed5c2511d.png">


2. When on a screen that contains the `BottomSheetModal`, the default disabled back behavior via Android's hardware back button was active even though the modal was closed. Now the disabled back behavior is disabled only when the modal is open