### PR TITLE
fix: fix sharing of observation on Android 12+

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39338,9 +39338,9 @@
       }
     },
     "react-native-share": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/react-native-share/-/react-native-share-3.7.0.tgz",
-      "integrity": "sha512-MCTGiPcBfelrnX/7n82N5eQAl31F6xljqFK2CWbPDTSt7bbJUZH3Znvy8KYePLYqAr7HVrk621eanQN6vSFMzA=="
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/react-native-share/-/react-native-share-8.2.2.tgz",
+      "integrity": "sha512-kVCI/cT0GnuYUTXe6mAimrjrnt4VWoRfrWqJZjFeoYFqAyOEfos84RC4eZlZnOT5eVtmTXRIkor5vgSkKOlZhw=="
     },
     "react-native-splash-screen": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-safe-area-context": "^3.4.1",
     "react-native-scale-bar": "^1.0.6",
     "react-native-screens": "^3.13.1",
-    "react-native-share": "^3.7.0",
+    "react-native-share": "^8.2.2",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.1.1",
     "react-native-tab-view": "^2.15.1",


### PR DESCRIPTION
Fixes #1097 

Notes:

- Upgrades `react-native-share` to latest (`8.2.2`). Fix was introduced in [`7.0.1`](https://github.com/react-native-share/react-native-share/releases/tag/v7.0.1).
- Slight uncertainty about the permissions change noted here: https://react-native-share.github.io/react-native-share/docs/migrate-v4-to-v5#removal-of-write_external_storage-permission-request. Not sure if it applies to us in this case (we're sharing file uris e.g. `file:///data/user/0/com.mapeo.debug/files/media/preview/8a/8a6e62b150eae104f2cd59c78aac8948.jpg`). from general testing, doesn't seem like the permission is needed to keep this working cc @gmaclennan 
- Steps to verify fix (must use Android 12+ device):

1. Create observation that has an attachment (e.g. photo)
2. Open observation screen
3. Press `Share` button