### PR TITLE
Hotfix/v5.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [5.6.2](https://github.com/digidem/mapeo-mobile/compare/v5.6.1...v5.6.2) (2023-05-25)
+
+### Bug Fixes
+
+- fix sharing of observation on Android 12+ ([4de6820](https://github.com/digidem/mapeo-mobile/commit/4de6820aefa5f723e7b87a332726818913c31fe8))
+
 ### [5.6.1](https://github.com/digidem/mapeo-mobile/compare/v5.6.0...v5.6.1) (2023-03-08)
 
 ## [5.6.0](https://github.com/digidem/mapeo-mobile/compare/v5.5.0...v5.6.0) (2023-01-16)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mapeo-mobile",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -39338,9 +39338,9 @@
       }
     },
     "react-native-share": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/react-native-share/-/react-native-share-3.7.0.tgz",
-      "integrity": "sha512-MCTGiPcBfelrnX/7n82N5eQAl31F6xljqFK2CWbPDTSt7bbJUZH3Znvy8KYePLYqAr7HVrk621eanQN6vSFMzA=="
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/react-native-share/-/react-native-share-8.2.2.tgz",
+      "integrity": "sha512-kVCI/cT0GnuYUTXe6mAimrjrnt4VWoRfrWqJZjFeoYFqAyOEfos84RC4eZlZnOT5eVtmTXRIkor5vgSkKOlZhw=="
     },
     "react-native-splash-screen": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "react-native-safe-area-context": "^3.4.1",
     "react-native-scale-bar": "^1.0.6",
     "react-native-screens": "^3.13.1",
-    "react-native-share": "^3.7.0",
+    "react-native-share": "^8.2.2",
     "react-native-splash-screen": "^3.2.0",
     "react-native-svg": "^12.1.1",
     "react-native-tab-view": "^2.15.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mapeo-mobile",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "private": true,
   "engines": {
     "node": "12.16.3"


### PR DESCRIPTION
Sharing observations containing attachments failed to work on Android 12+ due to an outdated dependency (react-native-share). This commit upgrades the dependency to its latest available version. See https://github.com/digidem/mapeo-mobile/pull/1098 for more details about the change.